### PR TITLE
Suggest using URNs for eventID and introduced eventGenerator

### DIFF
--- a/proposals/open-events/README.md
+++ b/proposals/open-events/README.md
@@ -14,7 +14,9 @@ Version 0.3 - 2017/09/20
 
 # Schema
 
-- **eventId** - *string* - ID of the event.  Can be specified by the producer.  The semantics of this string are explicitly undefined to ease the implementation of producers (e.g. a database commit ID).
+- **eventId** - *urn as string* - ID of the event.  The id should be a urn (rfc8141) so that the context of the event can be namespaced making the eventId unique. The nss part (rfc8141#2.2) should be specific to the generator. The semantics of the r-component (rfc8141#2.3.1) are explicitly undefined to ease the implementation of producers (e.g. a database commit ID). q and f components (rfc8141#2.3.2 and 2.3.3) should be avoided. 
+
+- **eventGenerator** - *uri as string* - Generator of the event, either a urn or url, provided the url is stable. This is to assist consumers discover the meaning of terms used throughout the message (eg relevance, format and meaning of eventType, resource.type, attributes etc). If a urn consumers will need to know how to resolve to a url.
 
 - **eventType** - *string* - Type of the event (e.g. `customer.created`).  Producers can specify the format of this, dependening on their service.  This specification does not (yet) enforce a type format (up for discussion).  We are also discussing putting the type version in here as well.
 


### PR DESCRIPTION
I dont know if pull requests from the community are appropriate, but this small change might improve the scalability of the proposal. Please feel free to modify, reject (or ignore/delete) the pull request if not appropriate.



In large systems, non namespaced eventIds will require that events are wrapped in an envelope to avoid collisions. There are no guarantee that a producer won't use a counter for its event ID. The urn provides a standards based mechanism of making the ID unique while still allowing the producer the flexibility to use the a commit ID.

Similarly without some context provided by the eventGenerator the consumer will require some out of band knowledge of the meaning of the event. Having a URI (urn or stable url) as an eventGenerator provides a mechanism by which the consumer can discover the meaning of data elements, without having to infer context from the eventType. Abstract eventTypes like "document.updated", "asset.created" may have different significance in different contexts.

Consumers don't have to resolve the urns or get the stable urls if a simple string match is sufficient, but it gives some context without additional envelopes.