### PR TITLE
Fix markdown and remove non-English characters

### DIFF
--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -157,11 +157,11 @@ the source video file and finally pass the results of the analysis to
 to different transcoding services (specified in the metadata) and then
 transitions to **'State3'**.
 
-Events **'Ev3'**, **'Ev4'** and **'Ev5**' are all event completion events from the
-transcoding services. This could be a notification event, etc. When either of
-**'Ev3'**, **'Ev4'** or **'Ev5'** is received, **'State3'** executes function
-**'F3'** which updates a database with success/failure depending upon the
-results present in the event. When all the events **'Ev3'**, **'Ev4'** and
+Events **'Ev3'**, **'Ev4'** and **'Ev5**' are all event completion events from
+the transcoding services. This could be a notification event, etc. When either
+of **'Ev3'**, **'Ev4'** or **'Ev5'** is received, **'State3'** executes
+function **'F3'** which updates a database with success/failure depending upon
+the results present in the event. When all the events **'Ev3'**, **'Ev4'** and
 **'Ev5'** are received, the flow ends.
 
 ### Loan Approval With a Long-Running Service Use Case
@@ -198,7 +198,8 @@ that the student has the cat.
 
 The flow translates this ambiguous sentence into another language once, and
 translate it back to English again. Then, the user compares the original
-ambiguous sentence with the final result to see if the ambiguous semantics is retained.
+ambiguous sentence with the final result to see if the ambiguous semantics
+is retained.
 
 The following diagram illustrates the basic flow for the translation service.
 
@@ -207,17 +208,17 @@ The following diagram illustrates the basic flow for the translation service.
 Flow:
 
 1. Parallel branch for AWS
-    - Sequence of Action: [ translate forward &rarr; translate backward &rarr; post
-        result to slack ]
+    - Sequence of Action: [ translate forward &rarr; translate backward &rarr;
+      post result to slack ]
 2. Parallel branch for Azure
-    - Sequence of Action: [ translate forward &rarr; translate backward &rarr; post
-        result to slack ]
+    - Sequence of Action: [ translate forward &rarr; translate backward &rarr;
+      post result to slack ]
 3. Parallel branch for GCP
-    - Sequence of Action: [ translate forward &rarr; translate backward &rarr; post
-        result to slack ]
+    - Sequence of Action: [ translate forward &rarr; translate backward &rarr;
+      post result to slack ]
 4. Parallel branch for IBM
-    - Sequence of Action: [ translate forward &rarr; translate backward &rarr; post
-        result to slack ]
+    - Sequence of Action: [ translate forward &rarr; translate backward &rarr;
+      post result to slack ]
 
 ## Functional Scope
 
@@ -421,9 +422,12 @@ An event trigger is defined in JSON as shown below.
 ```
 
 The "EVENT-NAME" is used by the EVENTS-EXPRESSION in an Event state.
-Note that the event itself is defined according to the [CloudEvents Specification](https://cloudevents.io/). The workflow only has a reference to the event name.
+Note that the event itself is defined according to the
+[CloudEvents Specification](https://cloudevents.io/). The workflow only has a
+reference to the event name.
 
-The field "source" specifies the event source UUID that identifies an event source.
+The field "source" specifies the event source UUID that identifies an event
+source.
 The field "correlation-token" specifies a path string to an identification label
 field in the event message that is used to correlate this event to other events
 associated with the same application workflow instance. For different events,
@@ -477,8 +481,9 @@ workflow will transit to end state.
 The field "action-mode" specifies whether functions are executed in sequence or
 in parallel and could either be SEQUENTIAL or PARALLEL.
 
-The "actions" field is a list of [ACTION-DEFINITION](#action-definition-(action-definition)) constructs that specify
-the list of functions to be performed when the event that matches the
+The "actions" field is a list of
+[ACTION-DEFINITION](#action-definition-(action-definition)) constructs that
+specify the list of functions to be performed when the event that matches the
 event-expression is received.
 
 The "next-state" field specifies the name of the next state to transition to
@@ -504,12 +509,15 @@ This is defined in JSON as shown below.
 ```
 
 - The "function" field specifies the function that must be invoked.
-- The "timeout" field specifies the maximum amount of time in seconds to wait for
-  the completion of the function's execution. This must be a positive integer. The
-  function timer is started when the request is sent to the invoked function.
+- The "timeout" field specifies the maximum amount of time in seconds to wait
+  for the completion of the function's execution. This must be a positive
+  integer.
+  The function timer is started when the request is sent to the invoked
+  function.
 - The "retry" field specifies how the result from a function is to be handled.
 - The "match" field specifies the matching value for the result.
-- The "retry-interval" and "max-retry" fields are used in case of an error result.
+- The "retry-interval" and "max-retry" fields are used in case of an error
+  result.
 - The "next-state" field specifies the name of the next state to transition to
   when exceeding max-retry limit.
 
@@ -527,8 +535,8 @@ This is defined in JSON as shown below.
   }
 ```
 
-- The field "action-mode" specifies whether functions are executed in sequence or
-  in parallel and could either be SEQUENTIAL or PARALLEL.
+- The field "action-mode" specifies whether functions are executed in sequence
+  or in parallel and could either be SEQUENTIAL or PARALLEL.
 - The "actions" field is a list of ACTION-DEFINITION constructs that specify the
   list of functions to be performed when the event that matches the
   event-expression is received.
@@ -591,8 +599,8 @@ This is defined in JSON as shown below.
   }
 ```
 
-- The "choices" field defines an ordered set of Match Rules against the input data
-to this state, and the next state to transition to for each match.
+- The "choices" field defines an ordered set of Match Rules against the input
+  data to this state, and the next state to transition to for each match.
 - The "path" field is a JSON Path that selects the value of the input data to
   be matched.
 - The "value" field is the matching value.
@@ -761,7 +769,8 @@ Each Filter has three kinds of path filters
 #### Example
 
 Compose the following two function "hello" and "save_result".
-The second function "save_result" cannot take the first function "hello" output as input.
+The second function "save_result" cannot take the first function "hello"
+output as input.
 
 - Function "hello":
 input {"name": String}

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1,43 +1,44 @@
 # Workflow - Version 0.1
 
-# Abstract #
+## Abstract
 
 Workflow is a vendor-neutral specification for defining the format/primitives
 that the users can use to specify/describe their serverless application flow.
 
-# Status of this document #
+## Status of this document
 
 This document is a working draft.
 
-# Table of Contents #
+## Table of Contents
+
 - [Introduction](#Introduction)
 - [Use Case Examples](#Use-Case-Examples)
 - [Functional Scope](#Functional-Scope)
 - [Workflow Model](#Workflow-Model)
 - [Workflow Specification](#Workflow-Specification)
 
-# Introduction #
+## Introduction
 
 Many serverless applications are not a simple function triggered by a single
 event, instead they are composed of multiple steps of function execution with
 functions in different steps triggered by different events. If a step involves
 multiple functions, the functions in that step might execute in sequence or in
 parallel or in branches depending on different event triggers. In order for a
-serverless platform to execute a serverless application’s function workflow
+serverless platform to execute a serverless application's function workflow
 correctly, the application developer needs to provide a workflow specification.
 
 The goal of the Serverless Workflow sub-group is to come up with a standard way
 for the users to specify their serverless application workflow to help
-facilitate portability of the Serverless application across different vendors’
+facilitate portability of the Serverless application across different vendors'
 platforms.
 
 This specification will meet the above goals as it describes a complete
 contract such that a given event timeline and workflow always produces the same
 set of side-effects.
 
-# Use Case Examples #
+## Use Case Examples
 
-## Home Monitoring Use Case ##
+### Home Monitoring Use Case
 
 A home security and monitoring system involves exterior door open sensor,
 window open sensor, exterior motion detectors, etc. in the house. The system
@@ -50,9 +51,9 @@ family member, it is a false alarm. Otherwise a text and email with the face
 image are sent to the two contacts on file. Then it will wait for response
 from the contacts.
 ---If there is no response within the predefined time period, it will initiate
-an auto-call to the customer and do voice recognition to get the customer’s
-response. If the customer’s response is OK, it is a false alarm. If the
-customer’s response is NOT OK or the customer gives the wrong secret code,
+an auto-call to the customer and do voice recognition to get the customer's
+response. If the customer's response is OK, it is a false alarm. If the
+customer's response is NOT OK or the customer gives the wrong secret code,
 a notification message is sent to the Emergency Services (fire, police and
 ambulance).
 ---If a response is received within the predefined time period, natural language
@@ -60,7 +61,7 @@ processing on the response will be initiated. If the response is OK, it is a
 false alarm. If the response is NOT OK or the customer gives the wrong secret
 code, a notification message is sent to the Emergency Services (fire, police
 and ambulance).
- 
+
 1. When the motion sensor is triggered, face recognition is done. If it is a
 family member, it is a false alarm. Otherwise it will wait to see whether there
 will be a door open or window open event. If there is no door open or window
@@ -68,9 +69,9 @@ open event, then it is a false alarm. If a door/window open event is received,
 a text and email message with the face image are sent to the two contacts on
 file. Then it will wait for response from the contacts.
 ---If there is no response within the predefined time period, it will initiate
-an auto-call to the customer and do voice recognition to get the customer’s
-response. If the customer’s response is OK, it is a false alarm. If the
-customer’s response is NOT OK or the customer gives the wrong secret code,
+an auto-call to the customer and do voice recognition to get the customer's
+response. If the customer's response is OK, it is a false alarm. If the
+customer's response is NOT OK or the customer gives the wrong secret code,
 a notification message is sent to the Emergency Services (fire, police and
 ambulance).
 ---If a response is received within the predefined time period, natural language
@@ -81,89 +82,89 @@ and ambulance).
 
 The following diagram shows the flow for a basic home monitoring application
 
-![](media/fed3443623fefd0797f9177871caa0c6.png)
+![home monitoring diagram](media/fed3443623fefd0797f9177871caa0c6.png)
 
-## Loan Approval Use Case ##
+### Loan Approval Use Case
 
 Every loan approval process begins with a customer entering his/her particulars
 along with the desired loan information. This information is typically entered
 via the web and the resulting form data is then stored in a DB or storage.
 
-The following diagram shows the flow for a basic loan approval application.  
+The following diagram shows the flow for a basic loan approval application.
 
-![](media/7fcc00c21ebfe7e410c906fdb6151ca1.png)
+![loan approval diagram](media/7fcc00c21ebfe7e410c906fdb6151ca1.png)
 
-**‘Ev1’** illustrates the resulting storage or DB event.
-**‘Ev1’** causes **‘State1’** to invoke function **‘F1’**. Function **‘F1’**
+**'Ev1'** illustrates the resulting storage or DB event.
+**'Ev1'** causes **'State1'** to invoke function **'F1'**. Function **'F1'**
 sends an email to an approving authority (Manager) and the flow transitions
-to **‘State2’**. The approving authority reaches a decision (based upon credit
+to **'State2'**. The approving authority reaches a decision (based upon credit
 scores and other factors) and updates the decision via storage/DB/API GW.
 
-**‘Ev2’** illustrates the decision event.**‘Ev2’** causes the flow to
-transition to **‘State3’**.
+**'Ev2'** illustrates the decision event.**'Ev2'** causes the flow to
+transition to **'State3'**.
 
-**‘State3’** invokes function ‘**F2’** (loan approval function) if **‘Ev2’**
-indicated loan approval or function **‘F3’** (loan rejection function) if
-**‘Ev2’** indicated loan rejection. After executing either **‘F2’** or **‘F3’**,
-the flow transitions to **‘End’** state.
+**'State3'** invokes function '**F2'** (loan approval function) if **'Ev2'**
+indicated loan approval or function **'F3'** (loan rejection function) if
+**'Ev2'** indicated loan rejection. After executing either **'F2'** or **'F3'**,
+the flow transitions to **'End'** state.
 
-## Employee Travel Booking Use Case ##
+### Employee Travel Booking Use Case
 
 The following diagram shows the basic flow for an employee travel booking.
 
-![](media/0926bf43d40b471a0c97304e347be8ab.png)
+![employee travel booking diagram](media/0926bf43d40b471a0c97304e347be8ab.png)
 
-The flow waits in **‘State1’** waiting for an event. **‘Ev1’** is typically
+The flow waits in **'State1'** waiting for an event. **'Ev1'** is typically
 a storage or DB event when an employee submits the travel request form. Upon
-receiving **‘Ev1’**, **‘State1’** executes function **‘F1’** and transitions to
-**‘State2’**.
+receiving **'Ev1'**, **'State1'** executes function **'F1'** and transitions to
+**'State2'**.
 
-In **‘State2’**, the flow is waiting for an approval / rejection event
-**‘Ev2’** from the employee’s manager. **‘Ev2’** could be a storage/DB/API GW
-event depending on the implementation. Upon receiving **‘Ev2’**, the workflow
-transitions to the next state **‘Approved ?’**.
+In **'State2'**, the flow is waiting for an approval / rejection event
+**'Ev2'** from the employee's manager. **'Ev2'** could be a storage/DB/API GW
+event depending on the implementation. Upon receiving **'Ev2'**, the workflow
+transitions to the next state **'Approved ?'**.
 
-In this state, the flow checks the results of **‘Ev2’**. If **‘Ev2’** result
-is “Reject”, the flow ends. If **‘Ev2’** result is “**Approved**”, then the
-flow transitions to **‘State3’**.
+In this state, the flow checks the results of **'Ev2'**. If **'Ev2'** result
+is "Reject", the flow ends. If **'Ev2'** result is "**Approved**", then the
+flow transitions to **'State3'**.
 
-**‘State3’** invokes multiple functions **‘F2’** and **‘F3’** to check the
-prices of various airlines. Once **‘F2’** and **‘F3’** complete, the flow
-transitions to **‘State4’** with the results of **‘F2’** and **‘F3’**
+**'State3'** invokes multiple functions **'F2'** and **'F3'** to check the
+prices of various airlines. Once **'F2'** and **'F3'** complete, the flow
+transitions to **'State4'** with the results of **'F2'** and **'F3'**
 
-In **‘State4’**, function **‘F4’** is invoked. **‘F4’** does a comparison of the
-results obtained from **‘State3’**. In addition to price, other factors such as
-time may be considered in evaluating the best flight. Once **‘F4’** completes,
-the flow transitions to **‘State5’**.
+In **'State4'**, function **'F4'** is invoked. **'F4'** does a comparison of the
+results obtained from **'State3'**. In addition to price, other factors such as
+time may be considered in evaluating the best flight. Once **'F4'** completes,
+the flow transitions to **'State5'**.
 
-**‘State5’** invoked **‘F5’** which completes the travel booking. After **‘F5’**
+**'State5'** invoked **'F5'** which completes the travel booking. After **'F5'**
 completes the flow ends.
 
-## Streaming Video-on-Demand Use Case ##
+### Streaming Video-on-Demand Use Case
 
 The following diagram illustrates the basic flow for streaming VOD.
 
-![](media/50e0bfccc80074c9681f943027c0e963.png)
+![streaming VoD diagram](media/50e0bfccc80074c9681f943027c0e963.png)
 
-**‘Ev1’** occurs when video with metadata has been uploaded to storage. This
-causes **‘State1’** to invoke the ingestion function **‘F1’** and transition to
-**‘State2’**. Function **‘F1’** is responsible for parsing the metadata file,
+**'Ev1'** occurs when video with metadata has been uploaded to storage. This
+causes **'State1'** to invoke the ingestion function **'F1'** and transition to
+**'State2'**. Function **'F1'** is responsible for parsing the metadata file,
 validate metadata file (E.g. make sure the source video file exists), analyze
 the source video file and finally pass the results of the analysis to
-**‘State2’**.
+**'State2'**.
 
-**‘State2’** executes function **‘F2’**. Function **‘F2’** queues the video file
+**'State2'** executes function **'F2'**. Function **'F2'** queues the video file
 to different transcoding services (specified in the metadata) and then
-transitions to **‘State3’**.
+transitions to **'State3'**.
 
-Events **‘Ev3’, ‘Ev4’ and ‘Ev5**’ are all event completion events from the
+Events **'Ev3'**, **'Ev4'** and **'Ev5**' are all event completion events from the
 transcoding services. This could be a notification event, etc. When either of
-**‘Ev3’**, **‘Ev4’** or **‘Ev5’** is received, **‘State3’** executes function
-**‘F3’** which updates a database with success/failure depending upon the
-results present in the event. When all the events **‘Ev3’**, **‘Ev4’** and
-**‘Ev5’** are received, the flow ends.
+**'Ev3'**, **'Ev4'** or **'Ev5'** is received, **'State3'** executes function
+**'F3'** which updates a database with success/failure depending upon the
+results present in the event. When all the events **'Ev3'**, **'Ev4'** and
+**'Ev5'** are received, the flow ends.
 
-## Loan Approval With a Long-Running Service Use Case ##
+### Loan Approval With a Long-Running Service Use Case
 
 A loan approval process begins when a user submits an online form. Then it
 performs some steps such as validating customer details, etc. At a certain
@@ -178,9 +179,9 @@ the message into the correct process instance.
 The following diagram illustrates the basic flow for the loan approval
 long-running service.
 
-![](media/230e5bf02f18561af9a7ba11c80032bd.png)
+![loan approval long-running service](media/230e5bf02f18561af9a7ba11c80032bd.png)
 
-## Translation Service Evaluation Use Case ##
+### Translation Service Evaluation Use Case
 
 In case of Artificial Intelligence services, specific service has different
 characteristics, strength, and weakness among providers. As an
@@ -188,43 +189,37 @@ example, this use case presents translation service evaluation flow among
 providers using an ambiguous sentence.
 
 In order to evaluate Translation Service in each provider, the flow uses an
-ambiguous sentence, "[the professor lectures to the student with the
-cat](about:blank)", it may be that the professor is lecturing with the cat, or
+ambiguous sentence:
+
+> The professor lectures to the student with the cat
+
+It may be that the professor is lecturing with the cat, or
 that the student has the cat.
 
 The flow translates this ambiguous sentence into another language once, and
-translate it back to English again.
-
-Then user compares the original ambiguous sentence with the final result to see
-if the ambiguous semantics is retained.
+translate it back to English again. Then, the user compares the original
+ambiguous sentence with the final result to see if the ambiguous semantics is retained.
 
 The following diagram illustrates the basic flow for the translation service.
 
-![](media/073a6d60f69df8bac37286a235c17ca4.png)
+![translation service](media/073a6d60f69df8bac37286a235c17ca4.png)
 
 Flow:
 
-1.  Parallel branch for AWS
-
-    -   Sequence of Action: [ translate forward -\> translate backward -\> post
+1. Parallel branch for AWS
+    - Sequence of Action: [ translate forward &rarr; translate backward &rarr; post
+        result to slack ]
+2. Parallel branch for Azure
+    - Sequence of Action: [ translate forward &rarr; translate backward &rarr; post
+        result to slack ]
+3. Parallel branch for GCP
+    - Sequence of Action: [ translate forward &rarr; translate backward &rarr; post
+        result to slack ]
+4. Parallel branch for IBM
+    - Sequence of Action: [ translate forward &rarr; translate backward &rarr; post
         result to slack ]
 
-2.  Parallel branch for Azure
-
-    -   Sequence of Action: [ translate forward -\> translate backward -\> post
-        result to slack ]
-
-3.  Parallel branch for GCP
-
-    -   Sequence of Action: [ translate forward -\> translate backward -\> post
-        result to slack ]
-
-4.  Parallel branch for IBM
-
-    -   Sequence of Action: [ translate forward -\> translate backward -\> post
-        result to slack ]
-
-# Functional Scope #
+## Functional Scope
 
 Function Workflow is used to orchestrate cloud functions into a coordinated
 micro-service application. Each function in the Function Workflow may be driven
@@ -233,38 +228,31 @@ and trigger events into a coherent unit and describe the execution of cloud
 functions and information passing in a prescribed manner. Specifically Function
 Workflow permits the user to:
 
-1.  Define the steps/states and workflow involved in a serverless application.
-
-2.  Define which functions are involved in each step.
-
-3.  Define which event or combination of events trigger the function or
+1. Define the steps/states and workflow involved in a serverless application.
+2. Define which functions are involved in each step.
+3. Define which event or combination of events trigger the function or
     functions.
-
-4.  Define how to arrange those functions to execute in sequence or in parallel
+4. Define how to arrange those functions to execute in sequence or in parallel
     if multiple functions are triggered.
-
-5.  Specify how information is filtered and passed from the event to the
+5. Specify how information is filtered and passed from the event to the
     function or between functions or between states.
-
-6.  Define error conditions with retries.
-
-7.  If a function is triggered by two or more events, define what label/key
+6. Define error conditions with retries.
+7. If a function is triggered by two or more events, define what label/key
     should be used to correlate those events to the same function workflow
     instance.
 
-The following is an example of a user’s Function Workflow that involves events
+The following is an example of a user's Function Workflow that involves events
 and functions. Using such a Function Workflow, the user can easily specify the
 interaction between events and functions as well as how information can be
 passed in the workflow.
 
-![](media/58265cad4415d262d5378f1ebe3f877d.png)
+![Function workflow diagram](media/58265cad4415d262d5378f1ebe3f877d.png)
 
 Function Workflow allows the user to define rendezvous points (states) to wait
 for predefined events before executing one or more cloud functions and
 progressing through the Function Workflow.
 
-# Workflow Model #
-
+## Workflow Model
 
 Function Workflow can be viewed as a collection of states and the transitions
 and branching between these states, and each state could have associated events
@@ -276,13 +264,13 @@ event or events from one or more event sources before performing their
 associated action and progressing to the next state. Additional workflow
 functionality includes:
 
--   Results from a cloud function can be used to initiate retry operations or
+- Results from a cloud function can be used to initiate retry operations or
     determine which function to execute next or which state to transition to.
 
--   Function Workflow provides a way to filter and transform the JSON event
+- Function Workflow provides a way to filter and transform the JSON event
     payload as it progresses through the Function Workflow.
 
--   Function Workflow provides a way for the application developer to specify a
+- Function Workflow provides a way for the application developer to specify a
     unique field in the event that can be used to correlate events from the
     event sources to the same function workflow instance
 
@@ -291,29 +279,28 @@ is a list of states provided by the definition/specification of a Function
 Workflow. The specification of a workflow is called a workflow template. The
 instantiation of the workflow template is called a workflow instance.
 
--   Event State: This state is used to wait for events from event sources and
+- Event State: This state is used to wait for events from event sources and
     then to invoke one or more functions to run in sequence or in parallel.
 
--   Operation State: This state allows one or more functions to run in sequence
+- Operation State: This state allows one or more functions to run in sequence
     or in parallel without waiting for any event.
 
--   Switch State: This state permits transitions to multiple other states (eg.
+- Switch State: This state permits transitions to multiple other states (eg.
     Different function results in the previous state trigger
     branching/transition to different next states).
 
--   Delay State: This state causes the workflow execution to delay for a
+- Delay State: This state causes the workflow execution to delay for a
     specified duration or until a specified time/date.
 
--   End State: This state terminates the workflow with Fail/Success.
+- End State: This state terminates the workflow with Fail/Success.
 
--   Parallel State. The Parallel state allows a number of states to execute in
+- Parallel State. The Parallel state allows a number of states to execute in
     parallel.
 
 Function Workflow is described by a Workflow Specification which is
 described in the following section.
 
-# Workflow Specification #
-
+## Workflow Specification
 
 The Function Workflow specification defines the behavior and operation of a
 Function Workflow. The Function Workflow specification constructs should allow
@@ -325,15 +312,17 @@ complex applications involving many cloud functions and multiple events.
 At high level, the Function Workflow specification consists of two parts:
 trigger definitions and state definitions.
 
-	"trigger-defs": {
-		TRIGGER-DEFINITION
-	},
-	
-	"states": {
-		STATE-DEFINITION
-	}
+```
+  "trigger-defs": {
+    TRIGGER-DEFINITION
+  },
 
-The trigger-defs field (Optional, only required if there are events associated
+  "states": {
+    STATE-DEFINITION
+  }
+```
+
+The trigger-defs field (only required if there are events associated
 with the workflow) is an array of event triggers associated with a Function
 Workflow. If there are multiple events involved in an application workflow, a
 correlation-token, which is used to correlate an event with other events for
@@ -345,89 +334,94 @@ Workflow.
 The following is an example of a Function Workflow in JSON format, which
 involves an Event State and the triggers for this Event State:
 
-	"trigger-defs": {
-		"OBS-EVENT": {
-			"source": CloudEvent source
-			“eventID”: CloudEvent eventID
-			“correlation-token”: a path string to an identification label field in the event message
-		},
-		"TIMER-EVENT": {
-			"source": CloudEvent source
-			“eventID”: CloudEvent eventID
-			“correlation-token”: a path string to an identification label field in the event message
-		},
-	},
-	"states": [
-		"STATE-OBS": {
-			"start": Boolean, ----specify this is a start state
-			"type": EVENT,
-			"events": [
-				{
-					"event-expression": boolean expression 1 of triggering events
-					"action-mode": Sequential or Parallel
-					"actions": [
-						{
-							"function": function name 1
-						},
-						{
-							"function": function name 2
-						}
-					],
-					"next-state": STATE-END
-				},
-				{
-					"event-expression": boolean expression 2 of triggering events
-					"action-mode": Sequential or Parallel
-					"actions": [
-						{
-							"function": function name 3
-						},
-						{
-							"function": function name 4
-						}
-					],
-					"next-state": STATE-END
-				}
-			]
-		},
-		"STATE-END": {
-			"type": END
-		}
-	]
+```
+  "trigger-defs": {
+    OBS-EVENT: {
+      "source": "CloudEvent source",
+      "eventID": "CloudEvent eventID",
+      "correlation-token": "A path string to an identification label field in the event message"
+    },
+    TIMER-EVENT: {
+      "source": "CloudEvent source",
+      "eventID": "CloudEvent eventID",
+      "correlation-token": "A path string to an identification label field in the event message"
+    },
+  },
+  "states": [
+    STATE-OBS: {
+      "start": Boolean, ----specify this is a start state
+      "type": "EVENT",
+      "events": [
+        {
+          "event-expression": boolean expression 1 of triggering events,
+          "action-mode": Sequential or Parallel,
+          "actions": [
+            {
+              "function": "function name 1"
+            },
+            {
+              "function": "function name 2"
+            }
+          ],
+          "next-state": STATE-END
+        },
+        {
+          "event-expression": boolean expression 2 of triggering events,
+          "action-mode": Sequential or Parallel,
+          "actions": [
+            {
+              "function": "function name 3"
+            },
+            {
+              "function": "function name 4"
+            }
+          ],
+          "next-state": STATE-END
+        }
+      ]
+    },
+    STATE-END: {
+      "type": "END"
+    }
+  ]
+```
 
 The following is another example of a Function Workflow with an Operation State:
 
-	"states": {
-		"STATE-ALARM-NOTIFY": {
-			"start": Boolean, ----specify this is a start state
-			"type": OPERATION,
-			"action-mode": Sequential or Parallel,
-			"actions": [
-				{
-					"function": function name 1
-				},
-				{
-					"function": function name 2
-				}
-			],
-			"next-state": "STATE-END"
-		}
-	}
+```
+  "states": {
+    STATE-ALARM-NOTIFY: {
+      "start": Boolean, ----specify this is a start state
+      "type": "OPERATION",
+      "action-mode": Sequential or Parallel,
+      "actions": [
+        {
+          "function": "function name 1"
+        },
+        {
+          "function": "function name 2"
+        }
+      ],
+      "next-state": STATE-END
+    }
+  }
+```
 
-## Trigger Definition(TRIGGER-DEFINITION) ##
+### Trigger definition (TRIGGER-DEFINITION)
 
-The TRIGGER-DEFINITION consists of one or more event triggers. 
+The TRIGGER-DEFINITION consists of one or more event triggers.
 
 An event trigger is defined in JSON as shown below.
 
-	"EVENT-NAME": {
-		"source": CloudEvent source UUID
-		"correlation-token": a path string to an identity label field in the event message
-		}	
+```json
+  EVENT-NAME: {
+    "source": "CloudEvent source UUID",
+    "correlation-token": "A path string to an identity label field in the event message"
+    }
+```
 
-The "EVENT-NAME” is used by the EVENTS-EXPRESSION in an Event state.
-Note that the event itself is defined according to the [CloudEvents Specification]
-(https://cloudevents.io/). The workflow only has a reference to the event name.
+The "EVENT-NAME" is used by the EVENTS-EXPRESSION in an Event state.
+Note that the event itself is defined according to the [CloudEvents Specification](https://cloudevents.io/). The workflow only has a reference to the event name.
 
 The field "source" specifies the event source UUID that identifies an event source.
 The field "correlation-token" specifies a path string to an identification label
@@ -439,28 +433,31 @@ A workflow could have a single event trigger or an array of event triggers. If
 it has an array of event triggers, a correlation-token specified as a JSON path
 in the event message must be specified.
 
-## State Definition(STATE-DEFINITION) ##
-### Event State ###
+### State definition (STATE-DEFINITION)
 
-	"STATE-NAME": {
-		"type": EVENT,
-		"start": Boolean,
-		"events": [
-			{
-				"event-expression": EVENTS-EXPRESSION,
-				"timeout": TIMEOUT-VALUE,
-				"action-mode": ACTION-MODE,
-				"actions": [
-					ACTION-DEFINITION,
-				],
-				"next-state": STATE-NAME
-			}
-		]
-	}
+#### Event state
+
+```
+  STATE-NAME: {
+    "type": "EVENT",
+    "start": Boolean,
+    "events": [
+      {
+        "event-expression": EVENTS-EXPRESSION,
+        "timeout": TIMEOUT-VALUE,
+        "action-mode": ACTION-MODE,
+        "actions": [
+          ACTION-DEFINITION,
+        ],
+        "next-state": STATE-NAME
+      }
+    ]
+  }
+```
 
 An Event State will have the "type" field set to value "EVENT".
 
-If the "start" field (Optional) is true, this is the start state. This must be
+If the "start" field (optional) is true, this is the start state. This must be
 true for one state only. If the "start" field is not present, the default value
 is false.
 
@@ -469,170 +466,160 @@ the event state.
 
 The "event-expression" field is a Boolean expression which consists of one or
 more Event operands and the Boolean operators. For example, an EVENTS-EXPRESSION
-could be “Event1 or Event2”. The first event that arrives and matches the
+could be "Event1 or Event2". The first event that arrives and matches the
 EVENTS-EXPRESSION will cause all actions for this state to be executed followed
 by a transition to the next state.
 
-The field “timeout” specifies the time period waiting for the events in the
+The field "timeout" specifies the time period waiting for the events in the
 EVENTS-EXPRESSION. If the events do not come within the timeout period, the
 workflow will transit to end state.
 
 The field "action-mode" specifies whether functions are executed in sequence or
 in parallel and could either be SEQUENTIAL or PARALLEL.
 
-The "actions" field is a list of **ACTION-DEFINITION** constructs that specify
+The "actions" field is a list of [ACTION-DEFINITION](#action-definition-(action-definition)) constructs that specify
 the list of functions to be performed when the event that matches the
 event-expression is received.
 
 The "next-state" field specifies the name of the next state to transition to
 after all the actions for the matching event have been successfully executed.
 
-**ACTION-DEFINITION**
+### Action definition (ACTION-DEFINITION)
 
 This is defined in JSON as shown below.
 
-	{ 
-		"function": FUNCTION-NAME,
-		"timeout": TIMEOUT-VALUE,
-		"retry": [
-			{ 
-				"match": RESULT-VALUE,
-				"retry-interval": INTERVAL-VALUE,
-				"max-retry": MAX-RETRY,
-				"next-state": STATE-NAME
-			}
-		],
-	}
+```
+  {
+    "function": FUNCTION-NAME,
+    "timeout": TIMEOUT-VALUE,
+    "retry": [
+      {
+        "match": RESULT-VALUE,
+        "retry-interval": INTERVAL-VALUE,
+        "max-retry": MAX-RETRY,
+        "next-state": STATE-NAME
+      }
+    ],
+  }
+```
 
-The "function" field specifies the function that must be invoked.
+- The "function" field specifies the function that must be invoked.
+- The "timeout" field specifies the maximum amount of time in seconds to wait for
+  the completion of the function's execution. This must be a positive integer. The
+  function timer is started when the request is sent to the invoked function.
+- The "retry" field specifies how the result from a function is to be handled.
+- The "match" field specifies the matching value for the result.
+- The "retry-interval" and "max-retry" fields are used in case of an error result.
+- The "next-state" field specifies the name of the next state to transition to
+  when exceeding max-retry limit.
 
-The "timeout" field specifies the maximum amount of time in seconds to wait for
-the completion of the function’s execution. This must be a positive integer. The
-function timer is started when the request is sent to the invoked function.
+### Operation state (OPERATION)
 
-The "retry" field specifies how the result from a function is to be handled.
+```
+  STATE-NAME: {
+    "type": "OPERATION",
+    "start": Boolean,
+    "action-mode": ACTION-MODE,
+    "actions": [
+      ACTION-DEFINITION,
+    ],
+    "next-state": STATE-NAME
+  }
+```
 
-The "match" field specifies the matching value for the result.
+- The field "action-mode" specifies whether functions are executed in sequence or
+  in parallel and could either be SEQUENTIAL or PARALLEL.
+- The "actions" field is a list of ACTION-DEFINITION constructs that specify the
+  list of functions to be performed when the event that matches the
+  event-expression is received.
+- The "next-state" field specifies the name of the next state to transition to
+  after all the actions for the matching event have been successfully executed.
 
-The "retry-interval" and "max-retry" fields are used in case of an error result.
+### Switch state (SWITCH)
 
-The "next-state" field specifies the name of the next state to transition to
-when exceeding max-retry limit.
+```
+  STATE-NAME: {
+    "type": "SWITCH",
+    "start": Boolean,
+    "choices": [
+      {
+        "path": PAYLOAD-PATH,
+        "value": VALUE,
+        "operator": COMPARISON-OPERATOR,
+        "next-state": STATE-NAME
+      },
+      {
+        "Not": {
+          "path": PAYLOAD-PATH,
+          "value": VALUE,
+          "operator": COMPARISON-OPERATOR
+        },
+        "next-state": STATE-NAME
+      },
+      {
+        "And": [
+          {
+            "path": PAYLOAD-PATH,
+            "value": VALUE,
+            "operator": COMPARISON-OPERATOR
+          },
+          {
+            "path": PAYLOAD-PATH,
+            "value": VALUE,
+            "operator": COMPARISON-OPERATOR
+          }
+        ],
+        "next-state": STATE-NAME
+      },
+      {
+        "Or": [
+          {
+            "path": PAYLOAD-PATH,
+            "value": VALUE,
+            "operator": COMPARISON-OPERATOR
+          },
+          {
+            "path": PAYLOAD-PATH,
+            "value": VALUE,
+            "operator": COMPARISON-OPERATOR
+          }
+        ],
+        "next-state": STATE-NAME
+      },
+    ],
+    "default": STATE-NAME
+  }
+```
 
-### Operation State
-
-	"STATE-NAME": {
-		"type": OPERATION,
-		"start": Boolean,
-			{
-				"action-mode": ACTION-MODE,
-				"actions": [
-					ACTION-DEFINITION,
-				],
-				"next-state": STATE-NAME
-			}
-	}
-
-The field "action-mode" specifies whether functions are executed in sequence or
-in parallel and could either be SEQUENTIAL or PARALLEL.
-
-The "actions" field is a list of ACTION-DEFINITION constructs that specify the
-list of functions to be performed when the event that matches the
-event-expression is received.
-
-The "next-state" field specifies the name of the next state to transition to
-after all the actions for the matching event have been successfully executed.
-
-### Switch State
-
-	"STATE-NAME": {
-		"type": SWITCH,
-		"start": Boolean,
-		"choices": [
-			{
-				"path": PAYLOAD-PATH,
-				"value": VALUE,
-				"operator": COMPARISON-OPERATOR,
-				"next-state": STATE-NAME
-			},
-			{ 
-				"Not": {
-					"path": PAYLOAD-PATH,
-					"value": VALUE,
-					"operator": COMPARISON-OPERATOR
-				},
-				"next-state": STATE-NAME
-			},
-			{
-				"And": [
-					{
-						"path": PAYLOAD-PATH,
-						"value": VALUE,
-						"operator": COMPARISON-OPERATOR
-					},
-					{
-						"path": PAYLOAD-PATH,
-						"value": VALUE,
-						"operator": COMPARISON-OPERATOR
-					}
-				],
-				"next-state": STATE-NAME
-			},
-			{
-				"Or": [
-					{
-						"path": PAYLOAD-PATH,
-						"value": VALUE,
-						"operator": COMPARISON-OPERATOR
-					},
-					{
-						"path": PAYLOAD-PATH,
-						"value": VALUE,
-						"operator": COMPARISON-OPERATOR
-					}
-				],
-				"next-state": STATE-NAME
-			},
-		],
-		"default": STATE-NAME
-	}
-
-The "choices" field defines an ordered set of Match Rules against the input data
+- The "choices" field defines an ordered set of Match Rules against the input data
 to this state, and the next state to transition to for each match.
+- The "path" field is a JSON Path that selects the value of the input data to
+  be matched.
+- The "value" field is the matching value.
+- The "operator" field specifies how the input data is compared with the
+  value, such as "EQ", "LT", "LTEQ", "GT", "GTEQ",
+  "StrEQ", "StrLT", "StrLTEQ", "StrGT", "StrGTEQ" .
+- The "next-state" field specifies the name of the next state to transition to
+  if there is a value match.
+- The "Not" field must be a single Match Rule that must not contain
+  "next-state" fields.
+- The "And" or "Or" field must be non-empty arrays of Match Rules that must
+  not themselves contain "next-state" fields.
+- The "default" field specifies the name of the next state if there is no match
+  for any choices value.
+- The order of evaluation is from the top to the bottom, and if a match happens,
+  go to "next-state" and ignore the rest of condition.
 
->   The "path" field is a JSON Path that selects the value of the input data to
->   be matched.
+#### Delay State
 
->   The "value” field is the matching value.
-
->   The "operator” field specifies how the input data is compared with the
->   value, such as “EQ”, “LT”, “LTEQ”, “GT”, “GTEQ”,
-
->   “StrEQ”, “StrLT”, “StrLTEQ”, “StrGT”, “StrGTEQ” .
-
->   The "next-state" field specifies the name of the next state to transition to
->   if there is a value match.
-
->   The “Not” field must be a single Match Rule that must not contain
->   “next-state” fields.
-
->   The “And” or “Or” field must be non-empty arrays of Match Rules that must
->   not themselves contain “next-state” fields.
-
-The "default" field specifies the name of the next state if there is no match
-for any choices value.
-
-The order of evaluation is form the top to the bottom, and if a match happens,
-go to “next-state” and ignore the rest of condition.
-
-### Delay State
-
-	"STATE-NAME": {
-		"type": DELAY,
-		"start": Boolean,
-		"time-delay": TIME-VALUE,
-		"next-state": STATE-NAME
-	}
+```
+  STATE-NAME: {
+    "type": "DELAY",
+    "start": Boolean,
+    "time-delay": TIME-VALUE,
+    "next-state": STATE-NAME
+  }
+```
 
 The "time-delay" field specifies a time delay. The TIME-VALUE is the amount of
 time in seconds to delay in this state. This must be a positive integer.
@@ -640,17 +627,19 @@ time in seconds to delay in this state. This must be a positive integer.
 The "next-state" field specifies the name of the next state to transition to.
 STATE-NAME must be a valid State name within the Function Workflow.
 
-### End State
+#### End State
 
-	"STATE-NAME": {
-		"type": END,
-		"status": STATUS
-	}
+```
+  STATE-NAME: {
+    "type": "END",
+    "status": STATUS
+  }
+```
 
-The “status” field specifies the workflow termination status: SUCCESS or
+The "status" field specifies the workflow termination status: SUCCESS or
 FAILURE.
 
-### Parallel State
+#### Parallel State
 
 The Parallel state consists of a number of states that are executed in parallel.
 A Parallel state has a number of branches that execute concurrently. Each branch
@@ -662,7 +651,7 @@ Parallel state.
 
 A Parallel state is defined by a state type Parallel and includes an array of
 parallel branches, each of which has its own separate states. Each branch
-receives a copy of the Parallel state’s input data. Any type of state may be
+receives a copy of the Parallel state's input data. Any type of state may be
 used in a branch except an END state.
 
 "next-state" transitions for states within a branch can only be to other states
@@ -672,23 +661,25 @@ to a state within a branch of a Parallel state.
 The Parallel state generates an output array in which each element is the output
 for a branch. The elements of the output array need not be of the same type.
 
-	"STATE-NAME": {
-		"type": PARALLEL,
-		"start": Boolean,
-		"branches": {
-			BRANCH-NAME {
-				"states": {
-					STATE-DEFINITION
-				}
-			},
-			BRANCH-NAME {
-				"states": {
-					STATE-DEFINITION
-				}
-			}
-		},
-		"next-state": "STATE-NAME"
-	}
+```
+  STATE-NAME: {
+    "type": "PARALLEL",
+    "start": Boolean,
+    "branches": {
+      BRANCH-NAME {
+        "states": {
+          STATE-DEFINITION
+        }
+      },
+      BRANCH-NAME {
+        "states": {
+          STATE-DEFINITION
+        }
+      }
+    },
+    "next-state": STATE-NAME
+  }
+```
 
 The "branches" field is a list of branches that are executed concurrently. Each
 named branch has a list of "states". The "next-state" field for each
@@ -702,7 +693,7 @@ name of the next state to transition to after all branches have completed
 execution. The STATE-NAME must be a valid State name within the Function
 Workflow, but it must not be a state within the Parallel state itself.
 
-## Information Passing ##
+### Information Passing
 
 The diagram below shows data flow through a Function Workflow that includes an
 Event state that invokes two serverless functions. Output data from one state is
@@ -723,7 +714,7 @@ received in a response from a serverless function may be transformed and
 combined with data received from a previous state before it is delivered in a
 response sent to the event source.
 
-![](media/e58a3f9dac9d6f68d378114e5e98ca05.png)
+![Async event information passing](media/e58a3f9dac9d6f68d378114e5e98ca05.png)
 
 There may be cases where an event source such as an API gateway expects to
 receive a response from the workflow. In this case CloudEvent metadata received
@@ -731,124 +722,105 @@ in a response from a serverless function may be transformed and combined with
 data received from a previous state before it is delivered in a response sent to
 the event source as shown below.
 
-![](media/3fee58bde24dd51ddcf083baee1cb8ac.png)
+![Sync event information passing](media/3fee58bde24dd51ddcf083baee1cb8ac.png)
 
-## Filter Mechanism ##
+### Filter Mechanism
 
 The state machine maintains an implicit JSON data which is accessed from each
-filter as JSONPath expression ‘\$’.
+filter as JSONPath expression '\$'.
 
 There are three kinds of filters
 
--   Event Filter
-
-    -   Invoked when data is passed from an event to the current state
-
--   State Filter
-
-    -   Invoked when data is passed from the previous state to the current state
-
-    -   Invoked when data is passed from the current state to the next state
-
--   Action Filter (Action means ACTION-DEFINITION which defines Serverless
+- Event Filter
+  - Invoked when data is passed from an event to the current state
+- State Filter
+  - Invoked when data is passed from the previous state to the current state
+  - Invoked when data is passed from the current state to the next state
+- Action Filter (Action means ACTION-DEFINITION which defines Serverless
     Function)
-
-    -   Invoked when data is passed from the current state to the first action
-
-    -   Invoked when data is passed from an action to action
-
-    -   Invoked when data is passed from the last action to the current state
+  - Invoked when data is passed from the current state to the first action
+  - Invoked when data is passed from an action to action
+  - Invoked when data is passed from the last action to the current state
 
 Each Filter has three kinds of path filters
 
--   InputPath
+- InputPath
+  - Select input data of either Event, State or Action as JSONPath
+  - Default value is '\$'
+- ResultPath
+  - Specify result JSON node of Action Output as JSONPath
+  - Default value is '\$'
+- OutputPath
+  - Specify output data of State or Action as JSONPath
+  - Default value is '\$'
 
-    -   Select input data of either Event, State or Action as JSONPath
+![Sequential filter diagram](media/2f84c6c905d1b66fc780f7ca6a444435.png)
 
-    -   Default value is ‘\$’
+![Parallel filter diagram](media/466d322720c67a60013f516f880c302f.png)
 
--   ResultPath
+#### Example
 
-    -   Specify result JSON node of Action Output as JSONPath
+Compose the following two function "hello" and "save_result".
+The second function "save_result" cannot take the first function "hello" output as input.
 
-    -   Default value is ‘\$’
-
--   OutputPath
-
-    -   Specify output data of State or Action as JSONPath
-
-    -   Default value is ‘\$’
-
-![](media/2f84c6c905d1b66fc780f7ca6a444435.png)
-
-![](media/466d322720c67a60013f516f880c302f.png)
-
-Example
-
-Compose the following two function “hello” and “save_result”. 
-The second function “save_result” cannot take the first function “hello” output as input.
-
-- Function “hello”: 
-input {“name”: String}
-output {“payload”: String}
-- Function “save_result”:
-input {“value1: String}
+- Function "hello":
+input {"name": String}
+output {"payload": String}
+- Function "save_result":
+input {"value1: String}
 output String
 
 CNCF Function Workflow Language
 
-	"states": {
-		"HelloWorld": {
-			"start": true,		
-			"type": OPERATION,
-			"action-mode": Sequential,
-			"actions": [
-				{
-					"function": “hello”
-				}
-			],
-			"next-state": "UpdateArg"
-		},
-		"UpdateArg": {
-			"start": false,		
-			"type": OPERATION,
-			"action-mode": Sequential,
-			"InputPath":"$.payload",
-			"ResultPath":"$.ifttt.value1",
-			"OutputPath":"$.ifttt",
-			"actions": [
-			],
-			"next-state": "SaveResult"
-		},
-		"SaveResult": {
-			"start": false,		
-			"type": OPERATION,
-			"action-mode": Sequential,
-			"actions": [
-				"function": “save_result”
-			],
-			"next-state": "STAE_END"
-		},
-		"STATE-END": {
-			"type": END
-		}
-	}
+```
+  "states": {
+    "HelloWorld": {
+      "start": true,
+      "type": "OPERATION",
+      "action-mode": Sequential,
+      "actions": [
+        {
+          "function": "hello"
+        }
+      ],
+      "next-state": "UpdateArg"
+    },
+    "UpdateArg": {
+      "start": false,
+      "type": "OPERATION",
+      "action-mode": Sequential,
+      "InputPath":"$.payload",
+      "ResultPath":"$.ifttt.value1",
+      "OutputPath":"$.ifttt",
+      "actions": [
+      ],
+      "next-state": "SaveResult"
+    },
+    "SaveResult": {
+      "start": false,
+      "type": "OPERATION",
+      "action-mode": Sequential,
+      "actions": [
+        "function": "save_result"
+      ],
+      "next-state": STATE_END
+    },
+    STATE-END: {
+      "type": "END"
+    }
+  }
+```
 
-![](media/04e21cfd16be62f9c650d7f15561a449.png)
+![Hello world diagram](media/04e21cfd16be62f9c650d7f15561a449.png)
 
-## Errors ##
+### Errors
 
 The state machine returns the following predefined Error Code during runtime.
-Typically it is used in the “retry” field of ACTION-DEFINITION.
+Typically it is used in the "retry" field of ACTION-DEFINITION.
 
--   SYS.Timeout
-
--   SYS.Fail
-
--   SYS.MatchAny
-
--   SYS.Permission
-
--   SYS.InvalidParameter
-
--   SYS.FilterError
+- SYS.Timeout
+- SYS.Fail
+- SYS.MatchAny
+- SYS.Permission
+- SYS.InvalidParameter
+- SYS.FilterError


### PR DESCRIPTION
Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>

* Replace non-English characters
* Add alt text for diagrams
* Remove trailing `#` for headers
* There should be only one H1 (# Title)
* Wrap code and use spaces instead of tabs
* Remove extra spaces and line breaks
