### PR TITLE
Removing end state

### DIFF
--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -9,10 +9,14 @@
       "description": "Workflow name",
       "minLength": 1
     },
+    "starts-at": {
+      "type": "string",
+      "description": "Starts at state name"
+    },
     "exec-status": {
       "type" : "string",
-      "enum": ["SYS.Timeout", "SYS.Fail", "SYS.Success", "SYS.InvalidParameter"],
-      "description": "Execution status"
+      "enum": ["Success", "Fail", "Timeout", "Invalid"],
+      "description": "Workflow execution status"
     },
     "trigger-defs": {
       "type": "array",
@@ -31,10 +35,6 @@
           {
             "title": "Delay State",
             "$ref": "#/definitions/delaystate"
-          },
-          {
-            "title": "End State",
-            "$ref": "#/definitions/endstate"
           },
           {
             "title": "Event State",
@@ -58,6 +58,7 @@
   },
   "required": [
     "name",
+    "starts-at",
     "states"
   ],
   "definitions": {
@@ -112,7 +113,7 @@
         },
         "timeout": {
           "type": "string",
-          "description": "Specifies the time period waiting for the events in the EVENTS-EXPRESSION"
+          "description": "Specifies the time period waiting for the events in the EVENTS-EXPRESSION (ISO 8601 format)"
         },
         "action-mode": {
           "type": "string",
@@ -149,10 +150,8 @@
           "$ref": "#/definitions/function"
         },
         "timeout": {
-          "type": "integer",
-          "default": "0",
-          "minimum": 0,
-          "description": "Specifies the time period waiting for the events in the EVENTS-EXPRESSION"
+          "type": "string",
+          "description": "Specifies the time period waiting for the events in the EVENTS-EXPRESSION (ISO 8601 format)"
         },
         "retry": {
           "type": "object",
@@ -173,10 +172,8 @@
           "description": "Specifies the matching value for the result"
         },
         "retry-interval": {
-          "type": "integer",
-          "default": "0",
-          "minimum": 0,
-          "description": "Specifies retry interval"
+          "type": "string",
+          "description": "Specifies retry interval (ISO 8601 format)"
         },
         "max-retry": {
           "type": "integer",
@@ -216,6 +213,10 @@
           "type": "string",
           "description": "Branch name"
         },
+        "starts-at": {
+          "type": "string",
+          "description": "Starts at state name"
+        },
         "states": {
           "type": "array",
           "description": "State Definitions",
@@ -237,10 +238,6 @@
               {
                 "title": "Switch State",
                 "$ref": "#/definitions/switchstate"
-              },
-              {
-                "title": "End State",
-                "$ref": "#/definitions/endstate"
               }
             ]
           }
@@ -251,7 +248,7 @@
           "description": "Flow must wait for this branch to finish before continuing"
         }
       },
-      "required": ["name", "states", "wait-for-completion"]
+      "required": ["name", "starts-at", "states", "wait-for-completion"]
     },
     "delaystate": {
       "type": "object",
@@ -268,51 +265,21 @@
           ],
           "description": "State type"
         },
-        "start": {
+        "end": {
           "type": "boolean",
           "default": false,
-          "description": "Is the start event"
+          "description": "Is this state an end state"
         },
         "filter": {
           "$ref": "#/definitions/filter"
         },
         "time-delay": {
-          "type": "integer",
-          "default": "0",
-          "minimum": 0,
-          "description": "Amount of time in seconds to delay in this state"
+          "type": "string",
+          "description": "Amount of time (ISO 8601 format) to delay"
         },
         "next-state": {
           "type": "string",
           "description": "Name of the next state to transition to after all the delay."
-        }
-      }
-    },
-    "endstate": {
-      "type": "object",
-      "description": "End State",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Unique name of the state"
-        },
-        "type": {
-          "type": "string",
-          "enum": [
-            "END"
-          ],
-          "description": "State type"
-        },
-        "filter": {
-          "$ref": "#/definitions/filter"
-        },
-        "status": {
-          "type": "string",
-          "enum": [
-            "SUCCESS",
-            "FAILURE"
-          ],
-          "description": "Specifies the workflow termination status"
         }
       }
     },
@@ -331,10 +298,10 @@
           ],
           "description": "State type"
         },
-        "start": {
+        "end": {
           "type": "boolean",
           "default": false,
-          "description": "Is the start event"
+          "description": "Is this state an end state"
         },
         "filter": {
           "$ref": "#/definitions/filter"
@@ -364,10 +331,10 @@
           ],
           "description": "State type"
         },
-        "start": {
+        "end": {
           "type": "boolean",
           "default": false,
-          "description": "Is the start event"
+          "description": "Is this state an end state"
         },
         "filter": {
           "$ref": "#/definitions/filter"
@@ -409,10 +376,10 @@
           ],
           "description": "State type"
         },
-        "start": {
+        "end": {
           "type": "boolean",
           "default": false,
-          "description": "Is the start event"
+          "description": "Is this state an end state"
         },
         "filter": {
           "$ref": "#/definitions/filter"
@@ -446,10 +413,10 @@
           ],
           "description": "State type"
         },
-        "start": {
+        "end": {
           "type": "boolean",
           "default": false,
-          "description": "Is the start event"
+          "description": "Is this state an end state"
         },
         "filter": {
           "$ref": "#/definitions/filter"

--- a/workflow/spec/spec-examples.md
+++ b/workflow/spec/spec-examples.md
@@ -8,11 +8,11 @@ used to access and reason over the workflow state.
 
 ```json
 {  
+   "starts-at": "HelloWorld",
    "states":[  
       {  
          "name":"HelloWorld",
          "type":"OPERATION",
-         "start":true,
          "action-mode":"Sequential",
          "actions":[  
             {  
@@ -24,7 +24,6 @@ used to access and reason over the workflow state.
       {  
          "name":"UpdateArg",
          "type":"OPERATION",
-         "start":false,
          "action-mode":"Sequential",
          "InputPath":"$.payload",
          "ResultPath":"$.ifttt.value1",
@@ -37,7 +36,7 @@ used to access and reason over the workflow state.
       {  
          "name":"SaveResult",
          "type":"OPERATION",
-         "start":false,
+         "end":true,
          "action-mode":"Sequential",
          "actions":[  
             {  
@@ -45,10 +44,6 @@ used to access and reason over the workflow state.
             }
          ],
          "next-state":"STATE_END"
-      },
-      {  
-         "name":"STATE-END",
-         "type":"END"
       }
    ]
 }

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -89,20 +89,6 @@ A Serverless Workflow can be naturally modeled as a state machine.
 Specification of a workflow is called a workflow template. 
 Instantiation of the workflow template is called a workflow instance.
 
-Serverless Workflow definition/specification provides following list of states:
-
-* **[Event State](#Event-State)**: Used to wait for events from event sources and then to invoke one or more functions to run in sequence or in parallel.
-
-* **[Operation State](#Operation-State)**: Allows one or more functions to run in sequence or in parallel without waiting for any event.
-
-* **[Switch State](#Switch-State)**: Permits transitions to multiple other states (eg. Different function results in the previous state trigger branching/transition to different next states).
-
-* **[Delay State](#Delay-State)**: Causes the workflow execution to delay for a specified duration or until a specified time/date.
-
-* **[Parallel State](#Parallel-State)**: Allows a number of states to execute in parallel.
-
-* **[End State](#End-State)**: Terminates the workflow with Fail/Success.
-
 ### Workflow Definition
 
 Here we define details of the Serverless Workflow definitions:
@@ -110,6 +96,7 @@ Here we define details of the Serverless Workflow definitions:
 | Parameter | Description | Type | Required |
 | --- | --- |  --- | --- |
 | name | Workflow name | string |yes |
+| starts-at |State name which is the starting state | string |yes |
 | exec-status |Workflow execution status | string |no |
 | [trigger-defs](#Trigger-Definition) |Array of workflow triggers | array | no |
 | [states](#State-Definition) | Array of workflow states | array | yes |
@@ -128,9 +115,13 @@ Here we define details of the Serverless Workflow definitions:
             "type": "string",
             "description": "Workflow name"
         },
+        "starts-at": {
+            "type": "string",
+            "description": "State name which is the starting state"
+        },
         "exec-status": {
             "type" : "string",
-            "enum": ["SYS.Timeout", "SYS.Fail", "SYS.Success", "SYS.InvalidParameter"],
+            "enum": ["Success", "Fail", "Timeout", "Invalid"],
             "description": "Execution status"
         },
         "trigger-defs": {
@@ -148,7 +139,6 @@ Here we define details of the Serverless Workflow definitions:
                 "type": "object",
                 "anyOf": [
                     { "$ref": "#definitions/delaystate" },
-                    { "$ref": "#definitions/endstate" },
                     { "$ref": "#definitions/eventstate" },
                     { "$ref": "#definitions/operationstate" },
                     { "$ref": "#definitions/parallelstate" },
@@ -157,7 +147,7 @@ Here we define details of the Serverless Workflow definitions:
             }
         }
     },
-    "required": ["name", "states"]
+    "required": ["name", "starts-at", "states"]
 }
 ```
 
@@ -225,8 +215,6 @@ States define building blocks of the Serverless Workflow. The specification defi
 
 - **[Parallel State](#Parallel-State)**: Allows a number of states to execute in
     parallel.
-
-- **[End State](#End-State)**: Terminates the workflow with Fail/Success.
     
 We will start defining each individual state:
 
@@ -236,7 +224,7 @@ We will start defining each individual state:
 | --- | --- | --- | --- |
 | name | state name (unique) | string | yes |
 | type |start type | string | yes |
-| start |Is this state a start state | boolean | no |
+| end |Is this state an end state | boolean | no |
 | [events](#eventstate-eventdef) |Array of event | array | yes |
  
 <details><summary><strong>Click to view JSON Schema</strong></summary>
@@ -256,10 +244,10 @@ We will start defining each individual state:
             "enum": ["EVENT"],
             "description": "State type"
         },
-        "start": {
+        "end": {
             "type": "boolean",
             "default": false,
-            "description": "Is the start event"
+            "description": "Is this an end state"
         },
         "events": {
             "type": "array",
@@ -284,7 +272,7 @@ Event state can hold one or more events definitions, so let's define those:
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | event-expression |Expression used to associate trigger-defs with event state  | string | yes |
-| timeout |Time period to wait for the events in the event-expression | string | no |
+| timeout |Time period to wait for the events in the event-expression (ISO 8601 format). For example: "PT15M" (wait 15 minutes), or "P2DT3H4M" (wait 2 days, 3 hours and 4 minutes)| string | no |
 | action-mode |Specifies if functions are executed in sequence of parallel | string | no |
 | [actions](#Action-Definition) |Array of actions | array | yes |
 | next-state|Next state to transition to after all the actions for the matching event have been successfully executed | string | yes |
@@ -302,7 +290,7 @@ Event state can hold one or more events definitions, so let's define those:
         },
         "timeout": {
             "type": "string",
-            "description": "Specifies the time period waiting for the events in the event-expression"
+            "description": "Specifies the time period waiting for the events in the event-expression (ISO 8601 format)"
         },
         "action-mode": {
             "type" : "string",
@@ -340,7 +328,7 @@ Each event state's event definition includes one or more actions. Let's define t
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | [function](#Function-Definition) |Function to be invoked | object | yes |
-| timeout |Max amount of time in seconds to wait for the completion of the function's execution | integer | no |
+| timeout |Max amount of time (ISO 8601 format) to wait for the completion of the function's execution. For example: "PT15M" (wait 15 minutes), or "P2DT3H4M" (wait 2 days, 3 hours and 4 minutes) | integer | no |
 | [retry](#Retry-Definition) |Defines if funtion execution needs a retry | object | no |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
@@ -355,10 +343,8 @@ Each event state's event definition includes one or more actions. Let's define t
             "description": "Function to be invoked"
         },
         "timeout": {
-            "type": "integer",
-            "default":"0",
-            "minimum": 0,
-            "description": "Specifies the maximum amount of time in seconds to wait for the completion of the function's execution. This must be a positive integer. The function timer is started when the request is sent to the invoked function"
+            "type": "string",
+            "description": "Specifies the maximum amount of time (ISO 8601 format) to wait for the completion of the function's execution. The function timer is started when the request is sent to the invoked function"
         },
         "retry": {
             "type": "object",
@@ -418,7 +404,7 @@ as well as define parameters (key/value pairs).
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | match |Result matching value | string | yes |
-| retry-interval |Interval value for retry | integer | no |
+| retry-interval |Interval value for retry (ISO 8601 repeatable format). For example: "R5/PT15M" (Starting from now repeat 5 times with 15 minute intervals)| integer | no |
 | max-retry |Max retry value | integer | no |
 | next-state |Name of the next state to transition to when exceeding max-retry limit | string | yes |
 
@@ -434,10 +420,8 @@ as well as define parameters (key/value pairs).
             "description": "Specifies the matching value for the result"
         },
         "retry-interval": {
-            "type": "integer",
-            "default":"0",
-            "minimum": 0,
-            "description": "Specifies retry interval"
+            "type": "string",
+            "description": "Specifies retry interval (ISO 8601 format)"
         },
         "max-retry": {
             "type": "integer",
@@ -462,7 +446,7 @@ as well as define parameters (key/value pairs).
 | --- | --- | --- | --- |
 | name |State name | string | yes |
 | type |State type | string | yes |
-| start |Is this event a start | boolean | no |
+| end |Is this state an end state | boolean | no |
 | action-mode |Should actions be executed sequentially or in parallel | string | yes |
 | [actions](#Action-Definition) |Array of actions | array | yes |
 | next-state |State to transition to after all the actions have been successfully executed | string | yes |
@@ -483,10 +467,10 @@ as well as define parameters (key/value pairs).
             "enum": ["OPERATION"],
             "description": "State type"
         },
-        "start": {
+        "end": {
             "type": "boolean",
             "default": false,
-            "description": "Is the start event"
+            "description": "Is this state an end state"
         },
         "action-mode": {
             "type" : "string",
@@ -523,7 +507,7 @@ actions execute, a transition to "next state" happens.
 | --- | --- | --- | --- |
 | name |State name | string | yes |
 | type |State type | string | yes |
-| start |Is this event a start | boolean | no | 
+| end |Is this state an end start | boolean | no | 
 | [choices](#switch-state-choices) |Ordered set of matching rules to determine which state to trigger next | array | yes |
 | default |Name of the next state if there is no match for any choices value | string | yes |
 
@@ -543,10 +527,10 @@ actions execute, a transition to "next state" happens.
             "enum": ["SWITCH"],
             "description": "State type"
         },
-        "start": {
+        "end": {
             "type": "boolean",
             "default": false,
-            "description": "Is the start event"
+            "description": "Is this state an end start"
         },
         "choices": {
             "type": "array",
@@ -769,8 +753,8 @@ There are found types of choices defined:
 | --- | --- | --- | --- |
 | name |State name | string | yes |
 | type |State type | string | yes |
-| start |If this is a start event | boolean | no |
-| time-delay |Amount of time (seconds) to delay when in this state | integer | yes |
+| time-delay |Amount of time (ISO 8601 format) to delay when in this state. For example: "PT15M" (delay 15 minutes), or "P2DT3H4M" (delay 2 days, 3 hours and 4 minutes) | integer | yes |
+| end |If this state an end state | boolean | no |
 | next-state |Name of the next state to transition to after the delay | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
@@ -789,16 +773,14 @@ There are found types of choices defined:
             "enum": ["DELAY"],
             "description": "State type"
         },
-        "start": {
+        "end": {
             "type": "boolean",
             "default": false,
-            "description": "Is the start event"
+            "description": "Is this state an end state"
         },
         "time-delay": {
-            "type": "integer",
-            "default":"0",
-            "minimum": 0,
-            "description": "Amount of time in seconds to delay in this state"
+            "type": "string",
+            "description": "Amount of time (ISO 8601 format) to delay"
         },
         "next-state": {
             "type": "string",
@@ -820,7 +802,7 @@ Delay state simple waits for a certain amount of time before transitioning to a 
 | --- | --- | --- | --- |
 | name |State name | string | yes | 
 | type |State type | string | yes | 
-| start |If this is a start event | boolean | no |
+| end |If this state and end state | boolean | no |
 | [branches](#parallel-state-branch) |List of branches for this parallel state| array | yes |
 | next-state |Name of the next state to transition to after all branches have completed execution | string | yes |
 
@@ -840,10 +822,10 @@ Delay state simple waits for a certain amount of time before transitioning to a 
             "enum": ["PARALLEL"],
             "description": "State type"
         },
-        "start": {
+        "end": {
             "type": "boolean",
             "default": false,
-            "description": "Is the start event"
+            "description": "Is this state an end state"
         },  
         "branches": {
             "type": "array",
@@ -866,8 +848,7 @@ Delay state simple waits for a certain amount of time before transitioning to a 
 
 Parallel state defines a collection of branches which are to be executed in parallel.
 Each branch consists of a collection of states. It can be regarded as a sub-workflow
-which must have a start (state with "start" property set to true) and an end state which
-represents its completion.
+which must have the starts-at property defined and a state which has the end property set to true.
 
 Let's define a branch now:
 
@@ -876,6 +857,7 @@ Let's define a branch now:
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | name |State name | string | yes |
+| starts-at |State name which is the start state | string | yes |
 | [states](#State-Definition) |List of states to be executed in this branch | array | yes |
 | wait-for-completion |If workflow execution must wait for this branch to finish before continuing | boolean | yes |
 
@@ -890,6 +872,10 @@ Let's define a branch now:
             "type": "string",
             "description": "Branch name"
         },
+        "starts-at": {
+            "type": "string",
+            "description": "State name which is the starting state"
+        },
         "states": {
             "type": "array",
             "description": "State Definitions",
@@ -900,8 +886,7 @@ Let's define a branch now:
                             { "$ref": "#definitions/eventstate" },
                             { "$ref": "#definitions/operationstate" },
                             { "$ref": "#definitions/parallelstate" },
-                            { "$ref": "#definitions/switchstate" },
-                            { "$ref": "#definitions/endstate" }
+                            { "$ref": "#definitions/switchstate" }
                         ]
                     }
         },
@@ -911,7 +896,7 @@ Let's define a branch now:
             "description": "Workflow execution must wait for this branch to finish before continuing"
         }
     },
-    "required": ["name", "states", "wait-for-completion"]
+    "required": ["name", "starts-at", "states", "wait-for-completion"]
 }
 ```
 
@@ -925,45 +910,6 @@ The elements of the output array need not be of the same type.
 
 The "wait-for-completion" property allows the parallel state to manage branch executions. If this flag is set to 
 true, the branches parallel parent state must wait for this branch to finish before continuing execution.
-
-### <img src="media/state-icon-small.png" with="30px" height="26px"/>End State
-
-| Parameter | Description | Type | Required |
-| --- | --- | --- | --- |
-| name |State name | string | yes |
-| type |State type | string | yes |
-| status |Workflow termination status | string | no |
-
-<details><summary><strong>Click to view JSON Schema</strong></summary>
-
-```json
-{
-    "type": "object",
-    "description": "End State",
-    "properties": {
-        "name": {
-            "type": "string",
-            "description": "Unique name of the state"
-        },
-        "type": {
-            "type" : "string",
-            "enum": ["END"],
-            "description": "State type"
-        },
-        "status": {
-            "type" : "string",
-            "enum": ["SUCCESS", "FAILURE"],
-            "description": "Specifies the workflow termination status"
-        }
-    },
-    "required": ["name", "type"]
-}
-```
-
-</details>
-
-End state defines the ending transition of the workflow. It provides a stats of successful or failed 
-workflow execution.
 
 ### Information Passing
 

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -757,7 +757,7 @@ There are found types of choices defined:
 | end |If this state an end state | boolean | no |
 | next-state |Name of the next state to transition to after the delay | string | yes |
 
-<details><summary><strong>Click to view JSON Schema</strong></summary>
+<details><summary><strong>Click to view JSON Schema</strong></summary> 
 
 ```json
 {


### PR DESCRIPTION
There is no need for us to have an explicit end state. in this pr:
* Adding "starts-at" property to workflow and branch definitions. This property defines the name of the state which is the starting state of the workflow.
* Adding "end" property to each state which states if this state is the ending state of the workflow.
* Removes end state
* Updates text and small fixes

I think this is a much better option and will:
* make the overall json shorter
* allow more flexibility for implementations
* follows closer other workflow impls such as step functions for example