### PR TITLE
Update retry in action definition

### DIFF
--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -193,10 +193,6 @@
         },
         "filter": {
           "$ref": "#/definitions/filter"
-        },
-        "default": {
-          "type": "string",
-          "description": "State to transition to in case there are errors and no retry definitions have been triggered"
         }
       },
       "required": ["function"]

--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -183,7 +183,7 @@
           "type": "string",
           "description": "Specifies the time period waiting for the events in the eventExpression (ISO 8601 format)"
         },
-        "retry-when": {
+        "retry": {
           "type": "array",
           "description": "Retry Definitions",
           "items": {
@@ -196,7 +196,7 @@
         },
         "default": {
           "type": "string",
-          "description": "State to transition to in case there are errors and no retry-when definitions have been triggered"
+          "description": "State to transition to in case there are errors and no retry definitions have been triggered"
         }
       },
       "required": ["function"]

--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -211,13 +211,13 @@
         },
         "max": {
           "type": "integer",
-          "default":"0",
+          "default": "0",
           "minimum": 0,
           "description": "Specifies the max retry"
         },
         "nextState": {
           "type": "string",
-          "description": "State to transition to when exceeding maxRetry limit"
+          "description": "State to transition to when exceeding max limit"
         }
       },
       "required": ["match", "nextState"]

--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -183,13 +183,20 @@
           "type": "string",
           "description": "Specifies the time period waiting for the events in the eventExpression (ISO 8601 format)"
         },
-        "retry": {
-          "type": "object",
-          "$ref": "#/definitions/retry",
-          "description": "Specifies how the result from a function is to be handled"
+        "retry-when": {
+          "type": "array",
+          "description": "Retry Definitions",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/retry"
+          }
         },
         "filter": {
           "$ref": "#/definitions/filter"
+        },
+        "default": {
+          "type": "string",
+          "description": "State to transition to in case there are errors and no retry-when definitions have been triggered"
         }
       },
       "required": ["function"]
@@ -202,20 +209,19 @@
           "type": "string",
           "description": "Specifies the matching value for the result"
         },
-        "retryInterval": {
+        "interval": {
           "type": "string",
           "description": "Specifies retry interval (ISO 8601 format)"
         },
-        "maxRetry": {
+        "max": {
           "type": "integer",
-          "default": "0",
+          "default":"0",
           "minimum": 0,
           "description": "Specifies the max retry"
         },
         "nextState": {
           "type": "string",
-          "description": "State to transition to when exceeding max-retry limit",
-          "minLength": 1
+          "description": "State to transition to when exceeding maxRetry limit"
         }
       },
       "required": ["match", "nextState"]

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -380,9 +380,8 @@ Each event state's event definition includes one or more actions. Let's define t
 | --- | --- | --- | --- |
 | [function](#Function-Definition) |Function to be invoked | object | yes |
 | timeout |Max amount of time (ISO 8601 format) to wait for the completion of the function's execution. For example: "PT15M" (wait 15 minutes), or "P2DT3H4M" (wait 2 days, 3 hours and 4 minutes) | integer | no |
-| [retry](#Retry-Definition) |Defines if funtion execution needs a retry | object | no |
+| [retry](#Retry-Definition) |Defines if function execution needs a retry | array | no |
 | [filter](#Filter-Definition) |Action data filter | object | yes |
-
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -400,9 +399,12 @@ Each event state's event definition includes one or more actions. Let's define t
             "description": "Specifies the maximum amount of time (ISO 8601 format) to wait for the completion of the function's execution. The function timer is started when the request is sent to the invoked function"
         },
         "retry": {
-            "type": "object",
-            "$ref": "#/definitions/retry",
-            "description": "Specifies how the result from a function is to be handled"
+            "type": "array",
+            "description": "Array of retry definitions",
+            "items": {
+                "type": "object",
+                "$ref": "#/definitions/retry"
+            }
         },
         "filter": {
           "$ref": "#/definitions/filter"
@@ -465,9 +467,9 @@ as well as define parameters (key/value pairs).
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | match |Result matching value | string | yes |
-| retryInterval |Interval value for retry (ISO 8601 repeatable format). For example: "R5/PT15M" (Starting from now repeat 5 times with 15 minute intervals)| integer | no |
-| maxRetry |Max retry value | integer | no |
-| [nextState](#Transitions) |State to transition to when exceeding maxRetry limit | string | yes |
+| interval |Interval value for retry (ISO 8601 repeatable format). For example: "R5/PT15M" (Starting from now repeat 5 times with 15 minute intervals)| integer | no |
+| max |Max retry value | integer | no |
+| [nextState](#Transitions) |State to transition to when exceeding max limit | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -480,11 +482,11 @@ as well as define parameters (key/value pairs).
             "type": "string",
             "description": "Specifies the matching value for the result"
         },
-        "retryInterval": {
+        "interval": {
             "type": "string",
             "description": "Specifies retry interval (ISO 8601 format)"
         },
-        "maxRetry": {
+        "max": {
             "type": "integer",
             "default":"0",
             "minimum": 0,
@@ -492,7 +494,7 @@ as well as define parameters (key/value pairs).
         },
         "nextState": {
             "type": "string",
-            "description": "State to transition to when exceeding maxRetry limit"
+            "description": "State to transition to when exceeding max limit"
         }
     },
     "required": ["match", "nextState"]


### PR DESCRIPTION
This updates the retry definition of actions. Main reason for update is that currently retry is a single element and it should be an array of retry definitions each matching on the return of the function call.

* Renamed to retry-when and is an array of retry definitions
* Retry definition parameters: match, interval, max-retry, next-state
* Added "default" parameter to Action definition. This defines the state to transition to if the function call fails (error) and none of the retry definitions define a match for it. 