### PR TITLE
Updating state transitions

### DIFF
--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -158,16 +158,16 @@
             "$ref": "#/definitions/action"
           }
         },
-        "nextState": {
+        "target": {
           "type": "string",
-          "description": "Name of the next state to transition to after all the actions for the matching event have been successfully executed",
+          "description": "State to transition to after all the actions for the matching event have been successfully executed",
           "minLength": 1
         },
         "filter": {
           "$ref": "#/definitions/filter"
         }
       },
-      "required": ["eventExpression", "timeout", "nextState"]
+      "required": ["eventExpression", "timeout", "target"]
     },
     "action": {
       "type": "object",
@@ -208,9 +208,9 @@
           "minimum": 0,
           "description": "Specifies the max retry"
         },
-        "nextState": {
+        "target": {
           "type": "string",
-          "description": "Name of the next state to transition to when exceeding maxRetry limit",
+          "description": "State to transition to when exceeding max-retry limit",
           "minLength": 1
         }
       }
@@ -281,9 +281,13 @@
       "type": "object",
       "description": "Causes the workflow execution to delay for a specified duration",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "State id"
+        },
         "name": {
           "type": "string",
-          "description": "Unique name of the state"
+          "description": "State name"
         },
         "type": {
           "type": "string",
@@ -304,9 +308,9 @@
           "type": "string",
           "description": "Amount of time (ISO 8601 format) to delay"
         },
-        "nextState": {
+        "target": {
           "type": "string",
-          "description": "Name of the next state to transition to after all the delay."
+          "description": "State to transition to after all the delay."
         }
       }
     },
@@ -314,9 +318,13 @@
       "type": "object",
       "description": "This state is used to wait for events from event sources and then to invoke one or more functions to run in sequence or in parallel.",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "State id"
+        },
         "name": {
           "type": "string",
-          "description": "Unique name of the state"
+          "description": "State name"
         },
         "type": {
           "type": "string",
@@ -347,9 +355,13 @@
       "type": "object",
       "description": "This state allows one or more functions to run in sequence or in parallel without waiting for any event.",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "State id"
+        },
         "name": {
           "type": "string",
-          "description": "Unique name of the state"
+          "description": "State name"
         },
         "type": {
           "type": "string",
@@ -382,9 +394,9 @@
             "$ref": "#/definitions/action"
           }
         },
-        "nextState": {
+        "target": {
           "type": "string",
-          "description": "Name of the next state to transition to after all the actions have been successfully executed"
+          "description": "State to transition to after all the actions have been successfully executed"
         }
       }
     },
@@ -392,9 +404,13 @@
       "type": "object",
       "description": "Consists of a number of states that are executed in parallel",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "State id"
+        },
         "name": {
           "type": "string",
-          "description": "Unique name of the state"
+          "description": "State name"
         },
         "type": {
           "type": "string",
@@ -419,9 +435,9 @@
             "$ref": "#/definitions/branch"
           }
         },
-        "nextState": {
+        "target": {
           "type": "string",
-          "description": "Specifies the name of the next state to transition to after all branches have completed execution"
+          "description": "State to transition to after all branches have completed execution"
         }
       }
     },
@@ -429,9 +445,13 @@
       "type": "object",
       "description": "Permits transitions to other states based on criteria matching",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "State id"
+        },
         "name": {
           "type": "string",
-          "description": "Unique name of the state"
+          "description": "State name"
         },
         "type": {
           "type": "string",
@@ -521,9 +541,9 @@
             "$ref": "#/definitions/defaultchoice"
           }
         },
-        "nextState": {
+        "target": {
           "type": "string",
-          "description": "Specifies the name of the next state to transition to if there is a value match"
+          "description": "State to transition to if there is a value match"
         }
       }
     },
@@ -539,9 +559,9 @@
             "$ref": "#/definitions/defaultchoice"
           }
         },
-        "nextState": {
+        "target": {
           "type": "string",
-          "description": "Specifies the name of the next state to transition to if there is a value match"
+          "description": "State to transition to if there is a value match"
         }
       }
     },
@@ -557,9 +577,9 @@
             "$ref": "#/definitions/defaultchoice"
           }
         },
-        "nextState": {
+        "target": {
           "type": "string",
-          "description": "Specifies the name of the next state to transition to if there is a value match"
+          "description": "State to transition to if there is a value match"
         }
       }
     },
@@ -572,9 +592,9 @@
           "$ref": "#/definitions/defaultchoice",
           "description": "Single Choice"
         },
-        "nextState": {
+        "target": {
           "type": "string",
-          "description": "Specifies the name of the next state to transition to if there is a value match"
+          "description": "State to transition to if there is a value match"
         }
       }
     }

--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -158,7 +158,7 @@
             "$ref": "#/definitions/action"
           }
         },
-        "target": {
+        "nextState": {
           "type": "string",
           "description": "State to transition to after all the actions for the matching event have been successfully executed",
           "minLength": 1
@@ -167,7 +167,7 @@
           "$ref": "#/definitions/filter"
         }
       },
-      "required": ["eventExpression", "timeout", "target"]
+      "required": ["eventExpression", "timeout", "nextState"]
     },
     "action": {
       "type": "object",
@@ -208,7 +208,7 @@
           "minimum": 0,
           "description": "Specifies the max retry"
         },
-        "target": {
+        "nextState": {
           "type": "string",
           "description": "State to transition to when exceeding max-retry limit",
           "minLength": 1
@@ -283,8 +283,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "State id",
-          "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+          "description": "Unique State id",
           "minLength": 1
         },
         "name": {
@@ -310,7 +309,7 @@
           "type": "string",
           "description": "Amount of time (ISO 8601 format) to delay"
         },
-        "target": {
+        "nextState": {
           "type": "string",
           "description": "State to transition to after all the delay."
         }
@@ -322,8 +321,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "State id",
-          "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+          "description": "Unique State id",
           "minLength": 1
         },
         "name": {
@@ -361,8 +359,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "State id",
-          "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+          "description": "Unique State id",
           "minLength": 1
         },
         "name": {
@@ -400,7 +397,7 @@
             "$ref": "#/definitions/action"
           }
         },
-        "target": {
+        "nextState": {
           "type": "string",
           "description": "State to transition to after all the actions have been successfully executed"
         }
@@ -412,8 +409,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "State id",
-          "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+          "description": "Unique State id",
           "minLength": 1
         },
         "name": {
@@ -443,7 +439,7 @@
             "$ref": "#/definitions/branch"
           }
         },
-        "target": {
+        "nextState": {
           "type": "string",
           "description": "State to transition to after all branches have completed execution"
         }
@@ -455,8 +451,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "State id",
-          "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+          "description": "Unique State id",
           "minLength": 1
         },
         "name": {
@@ -551,7 +546,7 @@
             "$ref": "#/definitions/defaultchoice"
           }
         },
-        "target": {
+        "nextState": {
           "type": "string",
           "description": "State to transition to if there is a value match"
         }
@@ -569,7 +564,7 @@
             "$ref": "#/definitions/defaultchoice"
           }
         },
-        "target": {
+        "nextState": {
           "type": "string",
           "description": "State to transition to if there is a value match"
         }
@@ -587,7 +582,7 @@
             "$ref": "#/definitions/defaultchoice"
           }
         },
-        "target": {
+        "nextState": {
           "type": "string",
           "description": "State to transition to if there is a value match"
         }
@@ -602,7 +597,7 @@
           "$ref": "#/definitions/defaultchoice",
           "description": "Single Choice"
         },
-        "target": {
+        "nextState": {
           "type": "string",
           "description": "State to transition to if there is a value match"
         }

--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -283,7 +283,9 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "State id"
+          "description": "State id",
+          "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+          "minLength": 1
         },
         "name": {
           "type": "string",
@@ -320,7 +322,9 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "State id"
+          "description": "State id",
+          "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+          "minLength": 1
         },
         "name": {
           "type": "string",
@@ -357,7 +361,9 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "State id"
+          "description": "State id",
+          "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+          "minLength": 1
         },
         "name": {
           "type": "string",
@@ -406,7 +412,9 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "State id"
+          "description": "State id",
+          "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+          "minLength": 1
         },
         "name": {
           "type": "string",
@@ -447,7 +455,9 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "State id"
+          "description": "State id",
+          "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+          "minLength": 1
         },
         "name": {
           "type": "string",

--- a/workflow/spec/spec-examples.md
+++ b/workflow/spec/spec-examples.md
@@ -19,7 +19,7 @@ used to access and reason over the workflow state.
                "function":"hello"
             }
          ],
-         "target":"UpdateArg"
+         "nextState":"UpdateArg"
       },
       {  
          "name":"UpdateArg",
@@ -31,7 +31,7 @@ used to access and reason over the workflow state.
          "actions":[  
 
          ],
-         "target":"SaveResult"
+         "nextState":"SaveResult"
       },
       {  
          "name":"SaveResult",
@@ -43,7 +43,7 @@ used to access and reason over the workflow state.
                "function":"save_resut"
             }
          ],
-         "target":"STATE_END"
+         "nextState":"STATE_END"
       },
       {  
          "name":"STATE-END",

--- a/workflow/spec/spec-examples.md
+++ b/workflow/spec/spec-examples.md
@@ -1,8 +1,8 @@
 ## Serverless Workflow Specification - Examples
 
 ### Hello World Example
-The following example illustrates a simple "Hello World" Serverless Workflow with three operation states
-and an end state. The digram below show how information is passed through the workflow and filter mechanism 
+The following example illustrates a simple "Hello World" Serverless Workflow with three operation states. 
+The digram below show how information is passed through the workflow and filter mechanism 
 used to access and reason over the workflow state.
 
 
@@ -42,12 +42,7 @@ used to access and reason over the workflow state.
             {  
                "function":"save_resut"
             }
-         ],
-         "nextState":"STATE_END"
-      },
-      {  
-         "name":"STATE-END",
-         "type":"END"
+         ]
       }
    ]
 }

--- a/workflow/spec/spec-examples.md
+++ b/workflow/spec/spec-examples.md
@@ -19,7 +19,7 @@ used to access and reason over the workflow state.
                "function":"hello"
             }
          ],
-         "nextState":"UpdateArg"
+         "target":"UpdateArg"
       },
       {  
          "name":"UpdateArg",
@@ -31,7 +31,7 @@ used to access and reason over the workflow state.
          "actions":[  
 
          ],
-         "nextState":"SaveResult"
+         "target":"SaveResult"
       },
       {  
          "name":"SaveResult",
@@ -43,7 +43,11 @@ used to access and reason over the workflow state.
                "function":"save_resut"
             }
          ],
-         "nextState":"STATE_END"
+         "target":"STATE_END"
+      },
+      {  
+         "name":"STATE-END",
+         "type":"END"
       }
    ]
 }

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -258,7 +258,7 @@ We will start defining each individual state:
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| id | State id | string | no |
+| id | Unique state id | string | no |
 | name | State name | string | yes |
 | type |start type | string | yes |
 | end |Is this state an end state | boolean | no |
@@ -275,8 +275,7 @@ We will start defining each individual state:
     "properties": {
         "id": {
             "type": "string",
-            "description": "State id",
-            "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+            "description": "Unique state id",
             "minLength": 1
         },
         "name": {
@@ -323,7 +322,7 @@ Event state can hold one or more events definitions, so let's define those:
 | actionMode |Specifies if functions are executed in sequence of parallel | string | no |
 | [actions](#Action-Definition) |Array of actions | array | yes |
 | [filter](#Filter-Definition) |Event data filter | object | yes |
-| [target](#Transitions) |State to transition to after all the actions for the matching event have been successfully executed | string | yes |
+| [nextState](#Transitions) |State to transition to after all the actions for the matching event have been successfully executed | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -356,12 +355,12 @@ Event state can hold one or more events definitions, so let's define those:
         "filter": {
           "$ref": "#/definitions/filter"
         },
-        "target": {
+        "nextState": {
             "type": "string",
             "description": "State to transition to after all the actions for the matching event have been successfully executed"
         }
     },
-    "required": ["event-expression", "actions", "filter", "target"]
+    "required": ["event-expression", "actions", "filter", "nextState"]
 }
 ```
 
@@ -369,7 +368,7 @@ Event state can hold one or more events definitions, so let's define those:
 
 The event expression attribute is used to associate this event state with one or more trigger events. 
 
-Note that each event definition has a "target" property, which is used to identify the state which 
+Note that each event definition has a "nextState" property, which is used to identify the state which 
 should get triggered after this event completes.
 
 Each event state's event definition includes one or more actions. Let's define these actions now:
@@ -462,7 +461,7 @@ as well as define parameters (key/value pairs).
 | match |Result matching value | string | yes |
 | retryInterval |Interval value for retry (ISO 8601 repeatable format). For example: "R5/PT15M" (Starting from now repeat 5 times with 15 minute intervals)| integer | no |
 | maxRetry |Max retry value | integer | no |
-| [target](#Transitions) |State to transition to when exceeding max-retry limit | string | yes |
+| [nextState](#Transitions) |State to transition to when exceeding max-retry limit | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -485,12 +484,12 @@ as well as define parameters (key/value pairs).
             "minimum": 0,
             "description": "Specifies the max retry"
         },
-        "target": {
+        "nextState": {
             "type": "string",
             "description": "State to transition to when exceeding max-retry limit"
         }
     },
-    "required": ["match", "target"]
+    "required": ["match", "nexttState"]
 }
 ```
 
@@ -500,14 +499,14 @@ as well as define parameters (key/value pairs).
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| id | State id | string | no |
+| id | Unique state id | string | no |
 | name |State name | string | yes |
 | type |State type | string | yes |
 | end |Is this state an end state | boolean | no |
 | actionMode |Should actions be executed sequentially or in parallel | string | yes |
 | [actions](#Action-Definition) |Array of actions | array | yes |
 | [filter](#Filter-Definition) |State data filter | object | yes |
-| [target](#Transitions) |State to transition to after all the actions have been successfully executed | string | yes |
+| [nextState](#Transitions) |State to transition to after all the actions have been successfully executed | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -518,8 +517,7 @@ as well as define parameters (key/value pairs).
     "properties": {
         "id": {
             "type": "string",
-            "description": "State id",
-            "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+            "description": "Unique state id",
             "minLength": 1
         },
         "name": {
@@ -552,12 +550,12 @@ as well as define parameters (key/value pairs).
         "filter": {
           "$ref": "#/definitions/filter"
         },
-        "target": {
+        "nextState": {
             "type": "string",
             "description": "State to transition to after all the actions have been successfully executed"
         }
     },
-    "required": ["name", "type", "actionMode", "actions", "filter", "target"]
+    "required": ["name", "type", "actionMode", "actions", "filter", "nextState"]
 }
 ```
 
@@ -572,8 +570,8 @@ actions execute, a transition to "next state" happens.
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| id | State id | string | no |
-| name |State name | string | yes |
+| id | Unique state id | string | no |
+| name |Unique state name | string | yes |
 | type |State type | string | yes |
 | end |Is this state an end start | boolean | no | 
 | [choices](#switch-state-choices) |Ordered set of matching rules to determine which state to trigger next | array | yes |
@@ -589,8 +587,7 @@ actions execute, a transition to "next state" happens.
     "properties": {
         "id": {
             "type": "string",
-            "description": "State id",
-            "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+            "description": "Unique state id",
             "minLength": 1
         },
         "name": {
@@ -655,7 +652,7 @@ There are found types of choices defined:
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | single |List of choices | array | yes |
-| [target](#Transitions) |State to transition to if there is valid match(es) | string | yes |
+| [nextState](#Transitions) |State to transition to if there is valid match(es) | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -683,12 +680,12 @@ There are found types of choices defined:
                 }
             }
         },
-        "target": {
+        "nextState": {
             "type": "string",
             "description": "Specifies the name of the next state to transition to if there is a value match"
         }
     },
-    "required": ["single", "target"]
+    "required": ["single", "nextState"]
 }
 ```
 
@@ -699,7 +696,7 @@ There are found types of choices defined:
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | and |List of choices | array | yes |
-| [target](#Transitions) |State to transition to if there is valid match(es) | string | yes |
+| [nextState](#Transitions) |State to transition to if there is valid match(es) | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -727,12 +724,12 @@ There are found types of choices defined:
                 }
             }
         },
-        "target": {
+        "nextState": {
             "type": "string",
             "description": "Specifies the name of the next state to transition to if there is a value match"
         }
     },
-    "required": ["and", "target"]
+    "required": ["and", "nextState"]
 }
 ```
 
@@ -743,7 +740,7 @@ There are found types of choices defined:
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | not |List of choices | array | yes |
-| [target](#Transitions) |State to transition to if there is valid match(es) | string | yes |
+| [nextState](#Transitions) |State to transition to if there is valid match(es) | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -771,12 +768,12 @@ There are found types of choices defined:
                 }
             }
         },
-        "target": {
+        "nextState": {
             "type": "string",
             "description": "Specifies the name of the next state to transition to if there is a value match"
         }
     },
-    "required": ["not", "target"]
+    "required": ["not", "nextState"]
 }
 ```
 
@@ -787,7 +784,7 @@ There are found types of choices defined:
 | Parameter | Description |  Type | Required |
 | --- | --- | --- | --- |
 | or |List of choices | array | yes | 
-| [target](#Transitions) |State to transition to if there is valid match(es) | string | yes |
+| [nextState](#Transitions) |State to transition to if there is valid match(es) | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -815,12 +812,12 @@ There are found types of choices defined:
                 }                              
             }
         },
-        "target": {
+        "nextState": {
             "type": "string",
             "description": "Specifies the name of the next state to transition to if there is a value match"
         }
     },
-    "required": ["or", "target"]
+    "required": ["or", "nextState"]
 }
 ```
 </details>
@@ -829,13 +826,13 @@ There are found types of choices defined:
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| id | State id | string | no |
+| id | Unique state id | string | no |
 | name |State name | string | yes |
 | type |State type | string | yes |
 | end |If this state an end state | boolean | no |
 | timeDelay |Amount of time (ISO 8601 format) to delay when in this state. For example: "PT15M" (delay 15 minutes), or "P2DT3H4M" (delay 2 days, 3 hours and 4 minutes) | integer | yes |
 | [filter](#Filter-Definition) |State data filter | object | yes |
-| [target](#Transitions) |State to transition to after the delay | string | yes |
+| [nextState](#Transitions) |State to transition to after the delay | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary> 
 
@@ -846,8 +843,7 @@ There are found types of choices defined:
     "properties": {
         "id": {
             "type": "string",
-            "description": "State id",
-            "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+            "description": "Unique state id",
             "minLength": 1
         },
         "name": {
@@ -871,12 +867,12 @@ There are found types of choices defined:
         "filter": {
           "$ref": "#/definitions/filter"
         },
-        "target": {
+        "nextState": {
             "type": "string",
             "description": "Name of the next state to transition to after the delay"
         }
     },
-    "required": ["name", "type", "timeDelay", "target"]
+    "required": ["name", "type", "timeDelay", "nextState"]
 }
 ```
 
@@ -889,13 +885,13 @@ Delay state simple waits for a certain amount of time before transitioning to a 
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| id | State id | string | no |
+| id | Unique state id | string | no |
 | name |State name | string | yes | 
 | type |State type | string | yes | 
 | end |If this state and end state | boolean | no |
 | [branches](#parallel-state-branch) |List of branches for this parallel state| array | yes |
 | [filter](#Filter-Definition) |State data filter | object | yes |
-| [target](#Transitions) |State to transition to after all branches have completed execution | string | yes |
+| [nextState](#Transitions) |State to transition to after all branches have completed execution | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -906,8 +902,7 @@ Delay state simple waits for a certain amount of time before transitioning to a 
     "properties": {
         "id": {
             "type": "string",
-            "description": "State id",
-            "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+            "description": "Unique State id",
             "minLength": 1
         },
         "name": {
@@ -935,12 +930,12 @@ Delay state simple waits for a certain amount of time before transitioning to a 
         "filter": {
           "$ref": "#/definitions/filter"
         },
-        "target": {
+        "nextState": {
             "type": "string",
             "description": "Specifies the name of the next state to transition to after all branches have completed execution"
         }
     },
-    "required": ["name", "type", "branches", "filter", "target"]
+    "required": ["name", "type", "branches", "filter", "nextState"]
 }
 ```
 
@@ -1049,14 +1044,14 @@ Filters are used for data flow through the workflow. This is described in detail
 
 ### Transitions
 Serverless workflow states can have one or more incoming and outgoing transitions (from/to other states).
-Each state has a "target" property which is a string value that determines which 
+Each state has a "nextState" property which is a string value that determines which 
 state to transition to. Implementors can choose to use the states "name" string property
-for determining the target state, however we realize that in most cases this is not an
+for determining the next state, however we realize that in most cases this is not an
 optimal solution that can lead to ambiguity. This is why each state also include an "id"
 property. Implementors can choose their own id generation strategy to populate the id property
-for each of the states and use it as the unique state identifier taht is to be used as the "target" value. 
+for each of the states and use it as the unique state identifier that is to be used as the "nextState" value. 
 
-So the options for target transitions are:
+So the options for next state transitions are:
 * Use the state name property
 * Use the state id property
 * Use a combination of name and id properties

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -489,7 +489,7 @@ as well as define parameters (key/value pairs).
             "description": "State to transition to when exceeding max-retry limit"
         }
     },
-    "required": ["match", "nexttState"]
+    "required": ["match", "nextState"]
 }
 ```
 

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -79,6 +79,8 @@ Serverless Workflow can be viewed as a collection of states and the transitions 
 Each state could have associated events and/or functions. Serverless Workflow may be invoked from a CLI command or triggered dynamically upon arrival of events from event sources. 
 An event from an event source may also be associated with a specific state within a Serverless Workflow. 
 States within a Serverless Workflow can wait on the arrival of an event or events from one or more event sources before performing their associated action and progressing to the next state. 
+See the [Transitions](#Transitions) section for more details on workflow state progressions.
+
 Additional workflow functionality includes:
 
 * Results from a cloud function can be used to initiate retry operations or determine which function to execute next or which state to transition to.
@@ -256,7 +258,8 @@ We will start defining each individual state:
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| name | state name (unique) | string | yes |
+| id | State id | string | no |
+| name | State name | string | yes |
 | type |start type | string | yes |
 | end |Is this state an end state | boolean | no |
 | [events](#eventstate-eventdef) |Array of event | array | yes |
@@ -270,9 +273,13 @@ We will start defining each individual state:
     "type": "object",
     "description": "This state is used to wait for events from event sources and then to invoke one or more functions to run in sequence or in parallel.",
     "properties": {
+        "id": {
+            "type": "string",
+            "description": "State id"
+        },
         "name": {
             "type": "string",
-            "description": "Unique name of the state"
+            "description": "State name"
         },
         "type": {
             "type" : "string",
@@ -314,7 +321,7 @@ Event state can hold one or more events definitions, so let's define those:
 | actionMode |Specifies if functions are executed in sequence of parallel | string | no |
 | [actions](#Action-Definition) |Array of actions | array | yes |
 | [filter](#Filter-Definition) |Event data filter | object | yes |
-| nextState|Next state to transition to after all the actions for the matching event have been successfully executed | string | yes |
+| [target](#Transitions) |State to transition to after all the actions for the matching event have been successfully executed | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -347,12 +354,12 @@ Event state can hold one or more events definitions, so let's define those:
         "filter": {
           "$ref": "#/definitions/filter"
         },
-        "nextState": {
+        "target": {
             "type": "string",
-            "description": "Name of the next state to transition to after all the actions for the matching event have been successfully executed"
+            "description": "State to transition to after all the actions for the matching event have been successfully executed"
         }
     },
-    "required": ["event-expression", "actions", "filter", "nextState"]
+    "required": ["event-expression", "actions", "filter", "target"]
 }
 ```
 
@@ -360,8 +367,8 @@ Event state can hold one or more events definitions, so let's define those:
 
 The event expression attribute is used to associate this event state with one or more trigger events. 
 
-Note that each event definition has a "nextState" property, which is used to idetify the state which 
-should get executed after this event completes (value should be the unique name of a state).
+Note that each event definition has a "target" property, which is used to identify the state which 
+should get triggered after this event completes.
 
 Each event state's event definition includes one or more actions. Let's define these actions now:
 
@@ -453,7 +460,7 @@ as well as define parameters (key/value pairs).
 | match |Result matching value | string | yes |
 | retryInterval |Interval value for retry (ISO 8601 repeatable format). For example: "R5/PT15M" (Starting from now repeat 5 times with 15 minute intervals)| integer | no |
 | maxRetry |Max retry value | integer | no |
-| nextState |Name of the next state to transition to when exceeding maxRetry limit | string | yes |
+| [target](#Transitions) |State to transition to when exceeding max-retry limit | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -476,12 +483,12 @@ as well as define parameters (key/value pairs).
             "minimum": 0,
             "description": "Specifies the max retry"
         },
-        "nextState": {
+        "target": {
             "type": "string",
-            "description": "Name of the next state to transition to when exceeding maxRetry limit"
+            "description": "State to transition to when exceeding max-retry limit"
         }
     },
-    "required": ["match", "nextState"]
+    "required": ["match", "target"]
 }
 ```
 
@@ -491,13 +498,14 @@ as well as define parameters (key/value pairs).
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
+| id | State id | string | no |
 | name |State name | string | yes |
 | type |State type | string | yes |
 | end |Is this state an end state | boolean | no |
 | actionMode |Should actions be executed sequentially or in parallel | string | yes |
 | [actions](#Action-Definition) |Array of actions | array | yes |
 | [filter](#Filter-Definition) |State data filter | object | yes |
-| nextState |State to transition to after all the actions have been successfully executed | string | yes |
+| [target](#Transitions) |State to transition to after all the actions have been successfully executed | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -506,9 +514,13 @@ as well as define parameters (key/value pairs).
     "type": "object",
     "description": "This state allows one or more functions to run in sequence or in parallel without waiting for any event.",
     "properties": {
+        "id": {
+            "type": "string",
+            "description": "State id"
+        },
         "name": {
             "type": "string",
-            "description": "Unique name of the state"
+            "description": "State name"
         },
         "type": {
             "type" : "string",
@@ -536,12 +548,12 @@ as well as define parameters (key/value pairs).
         "filter": {
           "$ref": "#/definitions/filter"
         },
-        "nextState": {
+        "target": {
             "type": "string",
-            "description": "Name of the next state to transition to after all the actions have been successfully executed"
+            "description": "State to transition to after all the actions have been successfully executed"
         }
     },
-    "required": ["name", "type", "actionMode", "actions", "filter", "nextState"]
+    "required": ["name", "type", "actionMode", "actions", "filter", "target"]
 }
 ```
 
@@ -556,6 +568,7 @@ actions execute, a transition to "next state" happens.
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
+| id | State id | string | no |
 | name |State name | string | yes |
 | type |State type | string | yes |
 | end |Is this state an end start | boolean | no | 
@@ -570,9 +583,13 @@ actions execute, a transition to "next state" happens.
     "type": "object",
     "description": "Permits transitions to other states based on criteria matching.",
     "properties": {
+        "id": {
+            "type": "string",
+            "description": "State id"
+        },
         "name": {
             "type": "string",
-            "description": "Unique name of the state"
+            "description": "State name"
         },
         "type": {
             "type" : "string",
@@ -632,7 +649,7 @@ There are found types of choices defined:
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | single |List of choices | array | yes |
-| nextState |Name of state to transition to if there is valid match(es) | string | yes |
+| [target](#Transitions) |State to transition to if there is valid match(es) | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -660,12 +677,12 @@ There are found types of choices defined:
                 }
             }
         },
-        "nextState": {
+        "target": {
             "type": "string",
             "description": "Specifies the name of the next state to transition to if there is a value match"
         }
     },
-    "required": ["single", "nextState"]
+    "required": ["single", "target"]
 }
 ```
 
@@ -676,7 +693,7 @@ There are found types of choices defined:
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | and |List of choices | array | yes |
-| nextState |Name of state to transition to if there is valid match(es) | string | yes |
+| [target](#Transitions) |State to transition to if there is valid match(es) | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -704,12 +721,12 @@ There are found types of choices defined:
                 }
             }
         },
-        "nextState": {
+        "target": {
             "type": "string",
             "description": "Specifies the name of the next state to transition to if there is a value match"
         }
     },
-    "required": ["and", "nextState"]
+    "required": ["and", "target"]
 }
 ```
 
@@ -720,7 +737,7 @@ There are found types of choices defined:
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | not |List of choices | array | yes |
-| nextState |Name of state to transition to if there is valid match(es) | string | yes |
+| [target](#Transitions) |State to transition to if there is valid match(es) | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -748,12 +765,12 @@ There are found types of choices defined:
                 }
             }
         },
-        "nextState": {
+        "target": {
             "type": "string",
             "description": "Specifies the name of the next state to transition to if there is a value match"
         }
     },
-    "required": ["not", "nextState"]
+    "required": ["not", "target"]
 }
 ```
 
@@ -764,7 +781,7 @@ There are found types of choices defined:
 | Parameter | Description |  Type | Required |
 | --- | --- | --- | --- |
 | or |List of choices | array | yes | 
-| nextState |Name of state to transition to if there is valid match(es) | string | yes |
+| [target](#Transitions) |State to transition to if there is valid match(es) | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -792,12 +809,12 @@ There are found types of choices defined:
                 }                              
             }
         },
-        "nextState": {
+        "target": {
             "type": "string",
             "description": "Specifies the name of the next state to transition to if there is a value match"
         }
     },
-    "required": ["or", "nextState"]
+    "required": ["or", "target"]
 }
 ```
 </details>
@@ -806,12 +823,13 @@ There are found types of choices defined:
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
+| id | State id | string | no |
 | name |State name | string | yes |
 | type |State type | string | yes |
 | end |If this state an end state | boolean | no |
 | timeDelay |Amount of time (ISO 8601 format) to delay when in this state. For example: "PT15M" (delay 15 minutes), or "P2DT3H4M" (delay 2 days, 3 hours and 4 minutes) | integer | yes |
 | [filter](#Filter-Definition) |State data filter | object | yes |
-| nextState |Name of the next state to transition to after the delay | string | yes |
+| [target](#Transitions) |State to transition to after the delay | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary> 
 
@@ -820,9 +838,13 @@ There are found types of choices defined:
     "type": "object",
     "description": "Causes the workflow execution to delay for a specified duration",
     "properties": {
+        "id": {
+            "type": "string",
+            "description": "State id"
+        },
         "name": {
             "type": "string",
-            "description": "Unique name of the state"
+            "description": "State name"
         },
         "type": {
             "type" : "string",
@@ -841,12 +863,12 @@ There are found types of choices defined:
         "filter": {
           "$ref": "#/definitions/filter"
         },
-        "nextState": {
+        "target": {
             "type": "string",
             "description": "Name of the next state to transition to after the delay"
         }
     },
-    "required": ["name", "type", "timeDelay", "nextState"]
+    "required": ["name", "type", "timeDelay", "target"]
 }
 ```
 
@@ -859,12 +881,13 @@ Delay state simple waits for a certain amount of time before transitioning to a 
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
+| id | State id | string | no |
 | name |State name | string | yes | 
 | type |State type | string | yes | 
 | end |If this state and end state | boolean | no |
 | [branches](#parallel-state-branch) |List of branches for this parallel state| array | yes |
 | [filter](#Filter-Definition) |State data filter | object | yes |
-| nextState |Name of the next state to transition to after all branches have completed execution | string | yes |
+| [target](#Transitions) |State to transition to after all branches have completed execution | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -873,9 +896,13 @@ Delay state simple waits for a certain amount of time before transitioning to a 
     "type": "object",
     "description": "Consists of a number of states that are executed in parallel",
     "properties": {
+        "id": {
+            "type": "string",
+            "description": "State id"
+        },
         "name": {
             "type": "string",
-            "description": "Unique name of the state"
+            "description": "State name"
         },
         "type": {
             "type" : "string",
@@ -898,12 +925,12 @@ Delay state simple waits for a certain amount of time before transitioning to a 
         "filter": {
           "$ref": "#/definitions/filter"
         },
-        "nextState": {
+        "target": {
             "type": "string",
             "description": "Specifies the name of the next state to transition to after all branches have completed execution"
         }
     },
-    "required": ["name", "type", "branches", "filter", "nextState"]
+    "required": ["name", "type", "branches", "filter", "target"]
 }
 ```
 
@@ -1009,6 +1036,20 @@ true, the branches parallel parent state must wait for this branch to finish bef
 </details>
 
 Filters are used for data flow through the workflow. This is described in detail in the [Information Passing](#Information-Passing) section.
+
+### Transitions
+Serverless workflow states can have one or more incoming transitions (from other states).
+Each state has a "target" property which is a string value that determines which 
+state to transition to. Implementors can choose to use the states "name" string property
+for determining the target state, however we realize that in most cases this is not an
+optimal solution that can lead to ambiguity. This is why each state also include an "id"
+property. Implementors can choose their own id generation strategy to populate the id property
+for each of the states and use it as the unique state identifier taht is to be used as the "target" value. 
+
+So the options for target transitions are:
+* Use the state name property
+* Use the state id property
+* Use a combination of name and id properties
 
 ### Information Passing
 

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -275,7 +275,9 @@ We will start defining each individual state:
     "properties": {
         "id": {
             "type": "string",
-            "description": "State id"
+            "description": "State id",
+            "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+            "minLength": 1
         },
         "name": {
             "type": "string",
@@ -516,7 +518,9 @@ as well as define parameters (key/value pairs).
     "properties": {
         "id": {
             "type": "string",
-            "description": "State id"
+            "description": "State id",
+            "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+            "minLength": 1
         },
         "name": {
             "type": "string",
@@ -585,7 +589,9 @@ actions execute, a transition to "next state" happens.
     "properties": {
         "id": {
             "type": "string",
-            "description": "State id"
+            "description": "State id",
+            "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+            "minLength": 1
         },
         "name": {
             "type": "string",
@@ -840,7 +846,9 @@ There are found types of choices defined:
     "properties": {
         "id": {
             "type": "string",
-            "description": "State id"
+            "description": "State id",
+            "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+            "minLength": 1
         },
         "name": {
             "type": "string",
@@ -898,7 +906,9 @@ Delay state simple waits for a certain amount of time before transitioning to a 
     "properties": {
         "id": {
             "type": "string",
-            "description": "State id"
+            "description": "State id",
+            "pattern": "$[a-zA-Z0-9\\-\\.]+^",
+            "minLength": 1
         },
         "name": {
             "type": "string",
@@ -1038,7 +1048,7 @@ true, the branches parallel parent state must wait for this branch to finish bef
 Filters are used for data flow through the workflow. This is described in detail in the [Information Passing](#Information-Passing) section.
 
 ### Transitions
-Serverless workflow states can have one or more incoming transitions (from other states).
+Serverless workflow states can have one or more incoming and outgoing transitions (from/to other states).
 Each state has a "target" property which is a string value that determines which 
 state to transition to. Implementors can choose to use the states "name" string property
 for determining the target state, however we realize that in most cases this is not an

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -461,7 +461,7 @@ as well as define parameters (key/value pairs).
 | match |Result matching value | string | yes |
 | retryInterval |Interval value for retry (ISO 8601 repeatable format). For example: "R5/PT15M" (Starting from now repeat 5 times with 15 minute intervals)| integer | no |
 | maxRetry |Max retry value | integer | no |
-| [nextState](#Transitions) |State to transition to when exceeding max-retry limit | string | yes |
+| [nextState](#Transitions) |State to transition to when exceeding maxRetry limit | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -486,7 +486,7 @@ as well as define parameters (key/value pairs).
         },
         "nextState": {
             "type": "string",
-            "description": "State to transition to when exceeding max-retry limit"
+            "description": "State to transition to when exceeding maxRetry limit"
         }
     },
     "required": ["match", "nextState"]


### PR DESCRIPTION
This PR updates the workflow state transitions.
Currently state transitions are based on the "next-state" property which should match an existing state name. Issues with that are:
* State name should be primarily used for display purposes (in notation for example)
* State name can include "special" (i18n) characters which can cause issues for implementations.
* There could be multiple states with the same name if the users chose to

So overall "name" property of a state does not guarantee uniqueness and can lead to transition problems/ambiguity.

In addition, the current transition based on "next" or "next-state" is exactly the same as in aws step functions. Even if that is probably a good strategy there, step functions have closed system implementation where they can guarantee uniqueness of the state name. For a specification which targets multiple implementations, that is not a good thing to enforce.

This pr:
* adds a not-required "id" property to each state.
* adds a "Transitions" section which describes the options implementations have in order to assure
the uniqueness and resolve ambiguities of state transitions.

