### PR TITLE
Proposal for new state: SubFlow State

### DIFF
--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -72,7 +72,7 @@
             "$ref": "#/definitions/switchstate"
           },
           {
-            "title": "Switch State",
+            "title": "Invoke State",
             "$ref": "#/definitions/invokestate"
           }
         ]
@@ -271,7 +271,7 @@
                 "$ref": "#/definitions/switchstate"
               },
               {
-                "title": "Switch State",
+                "title": "Invoke State",
                 "$ref": "#/definitions/invokestate"
               }
             ]

--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -70,6 +70,10 @@
           {
             "title": "Switch State",
             "$ref": "#/definitions/switchstate"
+          },
+          {
+            "title": "Switch State",
+            "$ref": "#/definitions/invokestate"
           }
         ]
       }
@@ -265,6 +269,10 @@
               {
                 "title": "Switch State",
                 "$ref": "#/definitions/switchstate"
+              },
+              {
+                "title": "Switch State",
+                "$ref": "#/definitions/invokestate"
               }
             ]
           }
@@ -503,6 +511,47 @@
           "description": "Specifies the name of the next state if there is no match for any choices value"
         }
       }
+    },
+    "invokestate": {
+      "type": "object",
+      "description": "Defines a local workflow to be executed",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique name of the state"
+        },
+        "type": {
+          "type" : "string",
+          "enum": ["INVOKE"],
+          "description": "State type"
+        },
+        "end": {
+          "type": "boolean",
+          "default": false,
+          "description": "Is this state an end state"
+        },
+        "wait-for-completion": {
+          "type": "boolean",
+          "default": false,
+          "description": "Workflow execution must wait for local workflow to finish before continuing."
+        },
+        "workflow-id": {
+          "type": "string",
+          "description": "Local workflow unique id."
+        },
+        "workflow-version": {
+          "type": "string",
+          "description": "Local workflow version"
+        },
+        "filter": {
+          "$ref": "#/definitions/filter"
+        },
+        "next-state": {
+          "type": "string",
+          "description": "Specifies the name of the next state to transition to after local workflow has completed execution."
+        }
+      },
+      "required": ["name", "type", "next-state", "workflow-id"]
     },
     "defaultchoice": {
       "type": "object",

--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -72,8 +72,8 @@
             "$ref": "#/definitions/switchstate"
           },
           {
-            "title": "Invoke State",
-            "$ref": "#/definitions/invokestate"
+            "title": "SubFlow State",
+            "$ref": "#/definitions/subflowstate"
           }
         ]
       }
@@ -271,8 +271,8 @@
                 "$ref": "#/definitions/switchstate"
               },
               {
-                "title": "Invoke State",
-                "$ref": "#/definitions/invokestate"
+                "title": "SubFlow State",
+                "$ref": "#/definitions/subflowstate"
               }
             ]
           }
@@ -512,9 +512,9 @@
         }
       }
     },
-    "invokestate": {
+    "subflowstate": {
       "type": "object",
-      "description": "Defines a local workflow to be executed",
+      "description": "Defines a sub-workflow to be executed",
       "properties": {
         "name": {
           "type": "string",
@@ -522,7 +522,7 @@
         },
         "type": {
           "type" : "string",
-          "enum": ["INVOKE"],
+          "enum": ["SUBFLOW"],
           "description": "State type"
         },
         "end": {
@@ -533,22 +533,18 @@
         "wait-for-completion": {
           "type": "boolean",
           "default": false,
-          "description": "Workflow execution must wait for local workflow to finish before continuing."
+          "description": "Workflow execution must wait for sub-workflow to finish before continuing."
         },
         "workflow-id": {
           "type": "string",
-          "description": "Local workflow unique id."
-        },
-        "workflow-version": {
-          "type": "string",
-          "description": "Local workflow version"
+          "description": "Sub-workflow unique id."
         },
         "filter": {
           "$ref": "#/definitions/filter"
         },
         "next-state": {
           "type": "string",
-          "description": "Specifies the name of the next state to transition to after local workflow has completed execution."
+          "description": "Specifies the name of the next state to transition to after sub-workflow has completed execution."
         }
       },
       "required": ["name", "type", "next-state", "workflow-id"]

--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -516,9 +516,14 @@
       "type": "object",
       "description": "Defines a sub-workflow to be executed",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique State id",
+          "minLength": 1
+        },
         "name": {
           "type": "string",
-          "description": "Unique name of the state"
+          "description": "State name"
         },
         "type": {
           "type" : "string",

--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -530,24 +530,24 @@
           "default": false,
           "description": "Is this state an end state"
         },
-        "wait-for-completion": {
+        "waitForCompletion": {
           "type": "boolean",
           "default": false,
           "description": "Workflow execution must wait for sub-workflow to finish before continuing."
         },
-        "workflow-id": {
+        "workflowId": {
           "type": "string",
           "description": "Sub-workflow unique id."
         },
         "filter": {
           "$ref": "#/definitions/filter"
         },
-        "next-state": {
+        "nextState": {
           "type": "string",
           "description": "Specifies the name of the next state to transition to after sub-workflow has completed execution."
         }
       },
-      "required": ["name", "type", "next-state", "workflow-id"]
+      "required": ["name", "type", "nextState", "workflowId"]
     },
     "defaultchoice": {
       "type": "object",

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1015,8 +1015,8 @@ true, the branches parallel parent state must wait for this branch to finish bef
 | name |State name | string | yes | 
 | type |State type | string | yes | 
 | end |If this state and end state | boolean | no |
-| wait-for-completion |If workflow execution must wait for sub-workflow to finish before continuing | boolean | yes |
-| workflow-id |Sub-workflow unique id | boolean | no |
+| waitForCompletion |If workflow execution must wait for sub-workflow to finish before continuing | boolean | yes |
+| workflowId |Sub-workflow unique id | boolean | no |
 | [filter](#Filter-Definition) |State data filter | object | yes |
 | next-state |Name of the next state to transition to after all branches have completed execution | string | yes |
 
@@ -1041,24 +1041,24 @@ true, the branches parallel parent state must wait for this branch to finish bef
             "default": false,
             "description": "Is this state an end state"
         },  
-        "wait-for-completion": {
+        "waitForCompletion": {
             "type": "boolean",
             "default": false,
             "description": "Workflow execution must wait for sub-workflow to finish before continuing."
         },
-        "workflow-id": {
+        "workflowId": {
             "type": "string",
             "description": "Sub-workflow unique id."
         },
         "filter": {
           "$ref": "#/definitions/filter"
         },
-        "next-state": {
+        "nextState": {
             "type": "string",
             "description": "Specifies the name of the next state to transition to after sub-workflow has completed execution."
         }
     },
-    "required": ["name", "type", "next-state", "workflow-id"]
+    "required": ["name", "type", "nextState", "workflowId"]
 }
 ```
 
@@ -1075,11 +1075,11 @@ in each branch, you could separate the branch states into individual sub-workflo
 as a single state in each.
 
 Sub-workflows must have a defined start and end states. 
-The wait-for-completion property defines if the SubFlow state should wait until execution of the sub-workflow
+The waitForCompletion property defines if the SubFlow state should wait until execution of the sub-workflow
 is completed or not. 
 
 Each sub-workflow receives a copy of the SubFlow state's input data.
-If wait-for-completion property is set to true, sub-workflows have the ability to edit the parent's workflow data.
+If waitForCompletion property is set to true, sub-workflows have the ability to edit the parent's workflow data.
 If this property is sete to false, data access to parent's workflow should not be allowed.
 
 

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -252,6 +252,8 @@ States define building blocks of the Serverless Workflow. The specification defi
 - **[Parallel State](#Parallel-State)**: Allows a number of states to execute in
     parallel.
     
+- **[Invoke State](#Invoke-State)**: Allows execution of an external serverless workflow.   
+    
 We will start defining each individual state:
 
 ### <img src="media/state-icon-small.png" with="30px" height="26px"/>Event State
@@ -1005,6 +1007,84 @@ The elements of the output array need not be of the same type.
 
 The "waitForCompletion" property allows the parallel state to manage branch executions. If this flag is set to 
 true, the branches parallel parent state must wait for this branch to finish before continuing execution.
+
+### <img src="media/state-icon-small.png" with="30px" height="26px"/>Invoke State
+
+| Parameter | Description | Type | Required |
+| --- | --- | --- | --- |
+| name |State name | string | yes | 
+| type |State type | string | yes | 
+| end |If this state and end state | boolean | no |
+| wait-for-completion |If workflow execution must wait for local workflow to finish before continuing | boolean | yes |
+| workflow-id |Local workflow unique id | boolean | no |
+| workflow-version |Local workflow version | boolean | no |
+| [filter](#Filter-Definition) |State data filter | object | yes |
+| next-state |Name of the next state to transition to after all branches have completed execution | string | yes |
+
+<details><summary><strong>Click to view JSON Schema</strong></summary>
+
+```json
+{
+    "type": "object",
+    "description": "Defines a local workflow to be executed",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Unique name of the state"
+        },
+        "type": {
+            "type" : "string",
+            "enum": ["INVOKE"],
+            "description": "State type"
+        },
+        "end": {
+            "type": "boolean",
+            "default": false,
+            "description": "Is this state an end state"
+        },  
+        "wait-for-completion": {
+            "type": "boolean",
+            "default": false,
+            "description": "Workflow execution must wait for local workflow to finish before continuing."
+        },
+        "workflow-id": {
+            "type": "string",
+            "description": "Local workflow unique id."
+        },
+        "workflow-version": {
+            "type": "string",
+            "description": "Local workflow version"
+        },
+        "filter": {
+          "$ref": "#/definitions/filter"
+        },
+        "next-state": {
+            "type": "string",
+            "description": "Specifies the name of the next state to transition to after local workflow has completed execution."
+        }
+    },
+    "required": ["name", "type", "next-state", "workflow-id"]
+}
+```
+
+</details>
+
+It is often the case that you want to group your workflows into small, **reusable** logical units that perform certain needed functionality.
+Even tho you can use the Event state to call an externally deployed serverless workflow (via function), at times
+there is a need to call a local workflow as well. In that case you would use the Invoke State.
+It also allows users to model their workflows with reusability and logical grouping in mind.
+
+This state allows you to call a uniquely identified local workflow and start its execution. 
+Another use of this state is within [branches](#parallel-state-branch) of the [Parallel State](#Parallel-State). Instead of having to define all states
+in each branch, you could separate the branch states into individual local workflows and call the Invoke state
+as a single state in each.
+
+The called local workflow must have a defined start and end states. 
+The wait-for-completion property defines if the Invoke state should wait until execution of the local workflow
+is completed or not. 
+
+Each local workflow receives a copy of the Invoke state's input data.
+
 
 ### Filter Definition
 

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -252,7 +252,7 @@ States define building blocks of the Serverless Workflow. The specification defi
 - **[Parallel State](#Parallel-State)**: Allows a number of states to execute in
     parallel.
     
-- **[Invoke State](#Invoke-State)**: Allows execution of a locally defined serverless workflow.   
+- **[SubFlow State](#SubFlow-State)**: Allows execution of a sub-workflow.   
     
 We will start defining each individual state:
 
@@ -1008,16 +1008,15 @@ The elements of the output array need not be of the same type.
 The "waitForCompletion" property allows the parallel state to manage branch executions. If this flag is set to 
 true, the branches parallel parent state must wait for this branch to finish before continuing execution.
 
-### <img src="media/state-icon-small.png" with="30px" height="26px"/>Invoke State
+### <img src="media/state-icon-small.png" with="30px" height="26px"/>SubFlow State
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | name |State name | string | yes | 
 | type |State type | string | yes | 
 | end |If this state and end state | boolean | no |
-| wait-for-completion |If workflow execution must wait for local workflow to finish before continuing | boolean | yes |
-| workflow-id |Local workflow unique id | boolean | no |
-| workflow-version |Local workflow version | boolean | no |
+| wait-for-completion |If workflow execution must wait for sub-workflow to finish before continuing | boolean | yes |
+| workflow-id |Sub-workflow unique id | boolean | no |
 | [filter](#Filter-Definition) |State data filter | object | yes |
 | next-state |Name of the next state to transition to after all branches have completed execution | string | yes |
 
@@ -1026,7 +1025,7 @@ true, the branches parallel parent state must wait for this branch to finish bef
 ```json
 {
     "type": "object",
-    "description": "Defines a local workflow to be executed",
+    "description": "Defines a sub-workflow to be executed",
     "properties": {
         "name": {
             "type": "string",
@@ -1034,7 +1033,7 @@ true, the branches parallel parent state must wait for this branch to finish bef
         },
         "type": {
             "type" : "string",
-            "enum": ["INVOKE"],
+            "enum": ["SUBFLOW"],
             "description": "State type"
         },
         "end": {
@@ -1045,22 +1044,18 @@ true, the branches parallel parent state must wait for this branch to finish bef
         "wait-for-completion": {
             "type": "boolean",
             "default": false,
-            "description": "Workflow execution must wait for local workflow to finish before continuing."
+            "description": "Workflow execution must wait for sub-workflow to finish before continuing."
         },
         "workflow-id": {
             "type": "string",
-            "description": "Local workflow unique id."
-        },
-        "workflow-version": {
-            "type": "string",
-            "description": "Local workflow version"
+            "description": "Sub-workflow unique id."
         },
         "filter": {
           "$ref": "#/definitions/filter"
         },
         "next-state": {
             "type": "string",
-            "description": "Specifies the name of the next state to transition to after local workflow has completed execution."
+            "description": "Specifies the name of the next state to transition to after sub-workflow has completed execution."
         }
     },
     "required": ["name", "type", "next-state", "workflow-id"]
@@ -1071,20 +1066,21 @@ true, the branches parallel parent state must wait for this branch to finish bef
 
 It is often the case that you want to group your workflows into small, **reusable** logical units that perform certain needed functionality.
 Even tho you can use the Event state to call an externally deployed services (via function), at times
-there is a need to include/nest another serverless workflow (from classpath/local file system etc). In that case you would use the Invoke State.
+there is a need to include/nest another serverless workflow (from classpath/local file system etc). In that case you would use the SubFlow State.
 It also allows users to model their workflows with reusability and logical grouping in mind.
 
-This state allows you to include/nest a uniquely identified workflow and start its execution. 
+This state allows you to include/nest a uniquely identified sub-workflow and start its execution. 
 Another use of this state is within [branches](#parallel-state-branch) of the [Parallel State](#Parallel-State). Instead of having to define all states
-in each branch, you could separate the branch states into individual included workflows and call the Invoke state
+in each branch, you could separate the branch states into individual sub-workflows and call the SubFlow state
 as a single state in each.
 
-The called included workflow must have a defined start and end states. 
-The wait-for-completion property defines if the Invoke state should wait until execution of the included workflow
+Sub-workflows must have a defined start and end states. 
+The wait-for-completion property defines if the SubFlow state should wait until execution of the sub-workflow
 is completed or not. 
 
-Each invoked workflow receives a copy of the Invoke state's input data.
-Included workflows executed are not allowed to edit the parent workflows' data.
+Each sub-workflow receives a copy of the SubFlow state's input data.
+If wait-for-completion property is set to true, sub-workflows have the ability to edit the parent's workflow data.
+If this property is sete to false, data access to parent's workflow should not be allowed.
 
 
 ### Filter Definition

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1070,11 +1070,11 @@ true, the branches parallel parent state must wait for this branch to finish bef
 </details>
 
 It is often the case that you want to group your workflows into small, **reusable** logical units that perform certain needed functionality.
-Even tho you can use the Event state to call an externally deployed serverless workflow (via function), at times
-there is a need to call a local workflow as well. In that case you would use the Invoke State.
+Even tho you can use the Event state to call an externally deployed services (via function), at times
+there is a need to include another serverless workflow (from classpath/local fily system etc). In that case you would use the Invoke State.
 It also allows users to model their workflows with reusability and logical grouping in mind.
 
-This state allows you to call a uniquely identified local workflow and start its execution. 
+This state allows you to call a uniquely identified workflow and start its execution. 
 Another use of this state is within [branches](#parallel-state-branch) of the [Parallel State](#Parallel-State). Instead of having to define all states
 in each branch, you could separate the branch states into individual local workflows and call the Invoke state
 as a single state in each.
@@ -1083,7 +1083,7 @@ The called local workflow must have a defined start and end states.
 The wait-for-completion property defines if the Invoke state should wait until execution of the local workflow
 is completed or not. 
 
-Each local workflow receives a copy of the Invoke state's input data.
+Each invoked workflow receives a copy of the Invoke state's input data.
 Local workflows executed are not allowed to edit the caller workflows' data.
 
 

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -252,7 +252,7 @@ States define building blocks of the Serverless Workflow. The specification defi
 - **[Parallel State](#Parallel-State)**: Allows a number of states to execute in
     parallel.
     
-- **[Invoke State](#Invoke-State)**: Allows execution of an external serverless workflow.   
+- **[Invoke State](#Invoke-State)**: Allows execution of a locally defined serverless workflow.   
     
 We will start defining each individual state:
 

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1071,20 +1071,20 @@ true, the branches parallel parent state must wait for this branch to finish bef
 
 It is often the case that you want to group your workflows into small, **reusable** logical units that perform certain needed functionality.
 Even tho you can use the Event state to call an externally deployed services (via function), at times
-there is a need to include/nest another serverless workflow (from classpath/local fily system etc). In that case you would use the Invoke State.
+there is a need to include/nest another serverless workflow (from classpath/local file system etc). In that case you would use the Invoke State.
 It also allows users to model their workflows with reusability and logical grouping in mind.
 
 This state allows you to include/nest a uniquely identified workflow and start its execution. 
 Another use of this state is within [branches](#parallel-state-branch) of the [Parallel State](#Parallel-State). Instead of having to define all states
-in each branch, you could separate the branch states into individual local workflows and call the Invoke state
+in each branch, you could separate the branch states into individual included workflows and call the Invoke state
 as a single state in each.
 
-The called local workflow must have a defined start and end states. 
-The wait-for-completion property defines if the Invoke state should wait until execution of the local workflow
+The called included workflow must have a defined start and end states. 
+The wait-for-completion property defines if the Invoke state should wait until execution of the included workflow
 is completed or not. 
 
 Each invoked workflow receives a copy of the Invoke state's input data.
-Local workflows executed are not allowed to edit the caller workflows' data.
+Included workflows executed are not allowed to edit the parent workflows' data.
 
 
 ### Filter Definition

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1084,6 +1084,7 @@ The wait-for-completion property defines if the Invoke state should wait until e
 is completed or not. 
 
 Each local workflow receives a copy of the Invoke state's input data.
+Local workflows executed are not allowed to edit the caller workflows' data.
 
 
 ### Filter Definition

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1065,7 +1065,7 @@ true, the branches parallel parent state must wait for this branch to finish bef
 </details>
 
 It is often the case that you want to group your workflows into small, **reusable** logical units that perform certain needed functionality.
-Even tho you can use the Event state to call an externally deployed services (via function), at times
+Even though you can use the Event state to call an externally deployed services (via function), at times
 there is a need to include/nest another serverless workflow (from classpath/local file system etc). In that case you would use the SubFlow State.
 It also allows users to model their workflows with reusability and logical grouping in mind.
 

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1071,10 +1071,10 @@ true, the branches parallel parent state must wait for this branch to finish bef
 
 It is often the case that you want to group your workflows into small, **reusable** logical units that perform certain needed functionality.
 Even tho you can use the Event state to call an externally deployed services (via function), at times
-there is a need to include another serverless workflow (from classpath/local fily system etc). In that case you would use the Invoke State.
+there is a need to include/nest another serverless workflow (from classpath/local fily system etc). In that case you would use the Invoke State.
 It also allows users to model their workflows with reusability and logical grouping in mind.
 
-This state allows you to call a uniquely identified workflow and start its execution. 
+This state allows you to include/nest a uniquely identified workflow and start its execution. 
 Another use of this state is within [branches](#parallel-state-branch) of the [Parallel State](#Parallel-State). Instead of having to define all states
 in each branch, you could separate the branch states into individual local workflows and call the Invoke state
 as a single state in each.

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1012,6 +1012,7 @@ true, the branches parallel parent state must wait for this branch to finish bef
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
+| id | Unique state id | string | no |
 | name |State name | string | yes | 
 | type |State type | string | yes | 
 | end |If this state and end state | boolean | no |
@@ -1027,9 +1028,14 @@ true, the branches parallel parent state must wait for this branch to finish bef
     "type": "object",
     "description": "Defines a sub-workflow to be executed",
     "properties": {
+        "id": {
+            "type": "string",
+            "description": "Unique State id",
+            "minLength": 1
+        },
         "name": {
             "type": "string",
-            "description": "Unique name of the state"
+            "description": "State name"
         },
         "type": {
             "type" : "string",
@@ -1066,10 +1072,11 @@ true, the branches parallel parent state must wait for this branch to finish bef
 
 It is often the case that you want to group your workflows into small, **reusable** logical units that perform certain needed functionality.
 Even though you can use the Event state to call an externally deployed services (via function), at times
-there is a need to include/nest another serverless workflow (from classpath/local file system etc). In that case you would use the SubFlow State.
+there is a need to include/inject another serverless workflow (from classpath/local file system etc, depending on the implementation logic). 
+In that case you would use the SubFlow State.
 It also allows users to model their workflows with reusability and logical grouping in mind.
 
-This state allows you to include/nest a uniquely identified sub-workflow and start its execution. 
+This state allows you to include/inject a uniquely identified sub-workflow and start its execution. 
 Another use of this state is within [branches](#parallel-state-branch) of the [Parallel State](#Parallel-State). Instead of having to define all states
 in each branch, you could separate the branch states into individual sub-workflows and call the SubFlow state
 as a single state in each.


### PR DESCRIPTION
State Description (also included in spec.md with this change):
********
It is often the case that you want to group your workflows into small, **reusable** logical units that perform certain needed functionality.
Even tho you can use the Event state to call an externally deployed services (via function), at times
there is a need to include/nest another serverless workflow (from classpath/local file system etc). In that case you would use the SubFlow State.
It also allows users to model their workflows with reusability and logical grouping in mind.

This state allows you to include/nest a uniquely identified sub-workflow and start its execution. 
Another use of this state is within [branches](#parallel-state-branch) of the [Parallel State](#Parallel-State). Instead of having to define all states
in each branch, you could separate the branch states into individual sub-workflows and call the SubFlow state
as a single state in each.

Sub-workflows must have a defined start and end states. 
The wait-for-completion property defines if the SubFlow state should wait until execution of the sub-workflow
is completed or not. 

Each sub-workflow receives a copy of the SubFlow state's input data.
If wait-for-completion property is set to true, sub-workflows have the ability to edit the parent's workflow data.
If this property is sete to false, data access to parent's workflow should not be allowed.
********

Similar states used in other "workflow" solutions:
BPMN2: "Call Activity"
Netflix Condutor: "Sub Workflow"

Depends on https://github.com/cncf/wg-serverless/pull/95 (where we add workflow "id" property) and https://github.com/cncf/wg-serverless/pull/86 (where we add the filter definition).