### PR TITLE
update state transitions

### DIFF
--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -114,7 +114,7 @@
       "type": "object",
       "properties": {
         "condition": {
-          "description": "Boolean expression which consists of one or more Event operands and the Boolean operators",
+          "description": "Boolean expression evaluated against state's data output. Must evaluate to true for the transition to be valid.",
           "$ref": "#/definitions/condition"
         },
         "nextState": {

--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -110,6 +110,23 @@
     "states"
   ],
   "definitions": {
+    "transition": {
+      "type": "object",
+      "properties": {
+        "condition": {
+          "description": "Boolean expression which consists of one or more Event operands and the Boolean operators",
+          "$ref": "#/definitions/condition"
+        },
+        "nextState": {
+          "type": "string",
+          "description": "State to transition to next",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "nextState"
+      ]
+    },
     "error": {
       "type": "object",
       "properties": {
@@ -120,15 +137,14 @@
         "filter": {
           "$ref": "#/definitions/filter"
         },
-        "nextState": {
-          "type": "string",
-          "description": "State to transition to if errors expressed in errorExpression are matched",
-          "minLength": 1
+        "transition": {
+          "description": "Transition definition when errors expressed in errorExpression are matched",
+          "$ref": "#/definitions/transition"
         }
       },
       "required": [
         "errorExpression",
-        "nextState"
+        "transition"
       ]
     },
     "triggerevent": {
@@ -205,10 +221,9 @@
             "$ref": "#/definitions/action"
           }
         },
-        "nextState": {
-          "type": "string",
-          "description": "State to transition to after all the actions for the matching event have been successfully executed",
-          "minLength": 1
+        "transition": {
+          "description": "Transition definition after all the actions for the matching event have been successfully executed",
+          "$ref": "#/definitions/transition"
         },
         "filter": {
           "$ref": "#/definitions/filter"
@@ -218,7 +233,7 @@
         "condition",
         "actions",
         "timeout",
-        "nextState"
+        "transition"
       ]
     },
     "action": {
@@ -262,14 +277,14 @@
           "minimum": 0,
           "description": "Specifies the max retry"
         },
-        "nextState": {
-          "type": "string",
-          "description": "State to transition to when exceeding max limit"
+        "transition": {
+          "description": "Transition definition when exceeding max limit",
+          "$ref": "#/definitions/transition"
         }
       },
       "required": [
         "match",
-        "nextState"
+        "transition"
       ],
       "function": {
         "type": "object",
@@ -393,9 +408,9 @@
               "$ref": "#/definitions/error"
             }
           },
-          "nextState": {
-            "type": "string",
-            "description": "State to transition to after all the delay."
+          "transition": {
+            "description": "Transition definition after the time delay",
+            "$ref": "#/definitions/transition"
           }
         },
         "if": {
@@ -418,7 +433,7 @@
             "name",
             "type",
             "timeDelay",
-            "nextState"
+            "transition"
           ]
         }
       },
@@ -531,9 +546,9 @@
               "$ref": "#/definitions/error"
             }
           },
-          "nextState": {
-            "type": "string",
-            "description": "State to transition to after all the actions have been successfully executed"
+          "transition": {
+            "description": "Transition definition after all the actions have been successfully executed",
+            "$ref": "#/definitions/transition"
           }
         },
         "if": {
@@ -557,7 +572,7 @@
             "type",
             "actionMode",
             "actions",
-            "nextState"
+            "transition"
           ]
         }
       },
@@ -608,9 +623,9 @@
               "$ref": "#/definitions/error"
             }
           },
-          "nextState": {
-            "type": "string",
-            "description": "State to transition to after all branches have completed execution"
+          "transition": {
+            "description": "Transition definition after all branches have completed execution",
+            "$ref": "#/definitions/transition"
           }
         },
         "if": {
@@ -632,7 +647,7 @@
             "name",
             "type",
             "branches",
-            "nextState"
+            "transition"
           ]
         }
       },
@@ -776,9 +791,9 @@
               "$ref": "#/definitions/error"
             }
           },
-          "nextState": {
-            "type": "string",
-            "description": "Specifies the name of the next state to transition to after sub-workflow has completed execution."
+          "transition": {
+            "description": "Transition definition after SubFlow has completed execution",
+            "$ref": "#/definitions/transition"
           }
         },
         "if": {
@@ -800,7 +815,7 @@
             "name",
             "type",
             "workflowId",
-            "nextState"
+            "transition"
           ]
         }
       },
@@ -843,16 +858,12 @@
             "$ref": "#/definitions/defaultchoice"
           },
           {
-            "properties": {
-              "nextState": {
-                "type": "string",
-                "description": "Specifies the name of the next state to transition to if there is a value match"
-              }
-            }
+            "$ref": "#/definitions/transition",
+            "description": "Transition definition if there is a value match"
           }
         ],
         "required": [
-          "nextState"
+          "transition"
         ]
       },
       "andchoice": {
@@ -867,14 +878,14 @@
               "$ref": "#/definitions/defaultchoice"
             }
           },
-          "nextState": {
-            "type": "string",
-            "description": "State to transition to if there is a value match"
+          "transition": {
+            "description": "Transition definition if there is a valid match",
+            "$ref": "#/definitions/transition"
           }
         },
         "required": [
           "and",
-          "nextState"
+          "transition"
         ]
       },
       "orchoice": {
@@ -889,14 +900,14 @@
               "$ref": "#/definitions/defaultchoice"
             }
           },
-          "nextState": {
-            "type": "string",
-            "description": "State to transition to if there is a value match"
+          "transition": {
+            "description": "Transition definition if there is a valid match",
+            "$ref": "#/definitions/transition"
           }
         },
         "required": [
           "or",
-          "nextState"
+          "transition"
         ]
       },
       "notchoice": {
@@ -908,14 +919,14 @@
             "$ref": "#/definitions/defaultchoice",
             "description": "Not Choice"
           },
-          "nextState": {
-            "type": "string",
-            "description": "State to transition to if there is a value match"
+          "transition": {
+            "description": "Transition definition if there is a valid match",
+            "$ref": "#/definitions/transition"
           }
         },
         "required": [
           "not",
-          "nextState"
+          "transition"
         ]
       },
       "condition": {

--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -138,7 +138,7 @@
           "$ref": "#/definitions/filter"
         },
         "transition": {
-          "description": "Transition definition when errors expressed in errorExpression are matched",
+          "description": "Next transition of the workflow when errors expressed in errorExpression are matched",
           "$ref": "#/definitions/transition"
         }
       },
@@ -222,7 +222,7 @@
           }
         },
         "transition": {
-          "description": "Transition definition after all the actions for the matching event have been successfully executed",
+          "description": "Next transition of the workflow after all the actions for the matching event have been successfully executed",
           "$ref": "#/definitions/transition"
         },
         "filter": {
@@ -278,7 +278,7 @@
           "description": "Specifies the max retry"
         },
         "transition": {
-          "description": "Transition definition when exceeding max limit",
+          "description": "Next transition of the workflow when exceeding max limit",
           "$ref": "#/definitions/transition"
         }
       },
@@ -409,7 +409,7 @@
             }
           },
           "transition": {
-            "description": "Transition definition after the time delay",
+            "description": "Next transition of the workflow after the time delay",
             "$ref": "#/definitions/transition"
           }
         },
@@ -547,7 +547,7 @@
             }
           },
           "transition": {
-            "description": "Transition definition after all the actions have been successfully executed",
+            "description": "Next transition of the workflow after all the actions have been successfully executed",
             "$ref": "#/definitions/transition"
           }
         },
@@ -624,7 +624,7 @@
             }
           },
           "transition": {
-            "description": "Transition definition after all branches have completed execution",
+            "description": "Next transition of the workflow after all branches have completed execution",
             "$ref": "#/definitions/transition"
           }
         },
@@ -792,7 +792,7 @@
             }
           },
           "transition": {
-            "description": "Transition definition after SubFlow has completed execution",
+            "description": "Next transition of the workflow after SubFlow has completed execution",
             "$ref": "#/definitions/transition"
           }
         },
@@ -859,7 +859,7 @@
           },
           {
             "$ref": "#/definitions/transition",
-            "description": "Transition definition if there is a value match"
+            "description": "Next transition of the workflow if there is a value match"
           }
         ],
         "required": [
@@ -879,7 +879,7 @@
             }
           },
           "transition": {
-            "description": "Transition definition if there is a valid match",
+            "description": "Next transition of the workflow if there is a valid match",
             "$ref": "#/definitions/transition"
           }
         },
@@ -901,7 +901,7 @@
             }
           },
           "transition": {
-            "description": "Transition definition if there is a valid match",
+            "description": "Next transition of the workflow if there is a valid match",
             "$ref": "#/definitions/transition"
           }
         },
@@ -920,7 +920,7 @@
             "description": "Not Choice"
           },
           "transition": {
-            "description": "Transition definition if there is a valid match",
+            "description": "Next transition of the workflow if there is a valid match",
             "$ref": "#/definitions/transition"
           }
         },

--- a/workflow/spec/spec-examples.md
+++ b/workflow/spec/spec-examples.md
@@ -16,22 +16,28 @@ used to access and reason over the workflow state.
          "actionMode":"Sequential",
          "actions":[  
             {  
-               "function":"hello"
+               "function":{
+                  "name": "helloWorldFunction",
+                  "resource": "functionResourse"
+               }
             }
          ],
-         "nextState":"UpdateArg"
+         "transition": {
+            "nextState":"UpdateArg"  
+         }
       },
       {  
          "name":"UpdateArg",
          "type":"OPERATION",
          "actionMode":"Sequential",
-         "inputPath":"$.payload",
-         "resultPath":"$.ifttt.value1",
-         "outputPath":"$.ifttt",
-         "actions":[  
-
-         ],
-         "nextState":"SaveResult"
+         "filter": {
+            "inputPath":"$.payload",
+            "resultPath":"$.ifttt.value1",
+            "outputPath":"$.ifttt"
+         },
+         "transition": {
+            "nextState":"SaveResult"
+         }
       },
       {  
          "name":"SaveResult",
@@ -40,7 +46,10 @@ used to access and reason over the workflow state.
          "actionMode":"Sequential",
          "actions":[  
             {  
-               "function":"save_resut"
+               "function":{
+                  "name": "saveResults",
+                  "resource": "functionResourse"
+               }
             }
          ]
       }

--- a/workflow/spec/spec-extending.md
+++ b/workflow/spec/spec-extending.md
@@ -31,12 +31,12 @@ So let's define a simple example workflow model and then add our custom extensio
 ```json
 {  
    "name": "Simple Workflow",
-   "starts-at": "FirstOperation",
+   "startsAt": "FirstOperation",
    "states":[  
       {  
          "name":"FirstOperation",
          "type":"OPERATION",
-         "action-mode":"Sequential",
+         "actionMode":"Sequential",
          "end": false,
          "actions":[  
             {  
@@ -47,13 +47,15 @@ So let's define a simple example workflow model and then add our custom extensio
                }
             }
          ],
-         "next-state":"SecondOperation"
+         "transition": {
+            "nextState": "SecondOperation"
+         }
       },
       {  
          "name":"SecondOperation",
          "type":"OPERATION",
          "end":true,
-         "action-mode":"Sequential",
+         "actionMode":"Sequential",
          "actions":[  
               {  
                  "name": "callSecondFunction",

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -604,6 +604,40 @@ as well as define parameters (key/value pairs).
 
 </details>
 
+#### Transition Definition
+
+| Parameter | Description | Type | Required |
+| --- | --- | --- | --- |
+| [condition](#Condition-Definition) |Boolean expression evaluated against state's data output. Must evaluate to true for the transition to be valid. | object | no |
+| [nextState](#Transitions) |State to transition to next | string | yes |
+
+<details><summary><strong>Click to view JSON Schema</strong></summary>
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "condition": {
+      "description": "Boolean expression evaluated against state's data output. Must evaluate to true for the transition to be valid.",
+      "$ref": "#/definitions/condition"
+    },
+    "nextState": {
+      "type": "string",
+      "description": "State to transition to next",
+      "minLength": 1
+    }
+  },
+  "required": [
+    "nextState"
+  ]
+}
+```
+
+</details>
+
+Defines Transitions from point A to point B in the serverless workflow. For more information see the
+[Transitions section](#Transitions).
+
 ### Operation State
 
 | Parameter | Description | Type | Required |

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -257,7 +257,7 @@ see the [Error Handling section](#Error-Handling).
 | --- | --- | --- | --- |
 | errorExpression | Boolean expression to match one or more errors | string |yes |
 | [filter](#Filter-Definition) |Error data filter | object | yes |
-| [transition](#Transitions) |Transition definition when errors expressed in errorExpression are matched | string | yes |
+| [transition](#Transitions) |Next transition of the workflow when an errors expressed in errorExpression are matched | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -275,7 +275,7 @@ see the [Error Handling section](#Error-Handling).
       "description": "Error data filter"
     },
     "transition": {
-      "description": "Transition definition when errors expressed in errorExpression are matched",
+      "description": "Next transition of the workflow when an errors expressed in errorExpression are matched",
       "$ref": "#/definitions/transition"
     }
   },
@@ -389,7 +389,7 @@ Event state can hold one or more events definitions, so let's define those:
 | actionMode |Specifies if functions are executed in sequence of parallel | string | no |
 | [actions](#Action-Definition) |Array of actions | array | yes |
 | [filter](#Filter-Definition) |Event data filter | object | yes |
-| [transition](#Transitions) |Transition definition after all the actions for the matching event have been successfully executed | string | yes |
+| [transition](#Transitions) |Next transition of the workflow after all the actions for the matching event have been successfully executed | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -423,7 +423,7 @@ Event state can hold one or more events definitions, so let's define those:
           "$ref": "#/definitions/filter"
         },
         "transition": {
-          "description": "Transition definition after all the actions for the matching event have been successfully executed",
+          "description": "Next transition of the workflow after all the actions for the matching event have been successfully executed",
           "$ref": "#/definitions/transition"
         }
     },
@@ -570,7 +570,7 @@ as well as define parameters (key/value pairs).
 | match |Result matching value | string | yes |
 | interval |Interval value for retry (ISO 8601 repeatable format). For example: "R5/PT15M" (Starting from now repeat 5 times with 15 minute intervals)| integer | no |
 | max |Max retry value | integer | no |
-| [transition](#Transitions) |Transition Definition when exceeding max limit | string | yes |
+| [transition](#Transitions) |Next transition of the workflow when exceeding max limit | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -594,7 +594,7 @@ as well as define parameters (key/value pairs).
             "description": "Specifies the max retry"
         },
         "transition": {
-          "description": "Transition definition when exceeding max limit",
+          "description": "Next transition of the workflow when exceeding max limit",
           "$ref": "#/definitions/transition"
         }
     },
@@ -651,7 +651,7 @@ Defines Transitions from point A to point B in the serverless workflow. For more
 | [filter](#Filter-Definition) |State data filter | object | yes |
 | [loop](#Loop-Definition) |State loop information | object | yes |
 | [onError](#Error-Handling) |States error handling definitions | array | no |
-| [transition](#Transitions) |Transition definition after all the actions have been successfully executed | string | yes (if end is set to false) |
+| [transition](#Transitions) |Next transition of the workflow after all the actions have been successfully executed | string | yes (if end is set to false) |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -707,7 +707,7 @@ Defines Transitions from point A to point B in the serverless workflow. For more
             }
         },
         "transition": {
-          "description": "Transition definition after all the actions have been successfully executed",
+          "description": "Next transition of the workflow after all the actions have been successfully executed",
           "$ref": "#/definitions/transition"
         }
     },
@@ -842,7 +842,7 @@ There are found types of choices defined:
 | path |Path that selects the data input value to be matched | string | yes |
 | value |Matching value | string | yes |
 | operator |Data Input comparator | string | yes |
-| [transition](#Transitions) |Transition Definition if there is valid matches | string | yes |
+| [transition](#Transitions) |Next transition of the workflow if there is valid matches | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -865,7 +865,7 @@ There are found types of choices defined:
             "description": "Specifies how data input is compared with the value"
         },
         "transition": {
-          "description": "Transition definition if there is valid matches",
+          "description": "Next transition of the workflow if there is valid matches",
           "$ref": "#/definitions/transition"
         }
     },
@@ -883,7 +883,7 @@ There are found types of choices defined:
 | path |Path that selects the data input value to be matched | string | yes |
 | value |Matching value | string | yes |
 | operator |Data Input comparator | string | yes |
-| [transition](#Transitions) |Transition Definition if there is valid matches | string | yes |
+| [transition](#Transitions) |Next transition of the workflow if there is valid matches | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -912,7 +912,7 @@ There are found types of choices defined:
             }
         },
         "transition": {
-          "description": "Transition definition if there is valid matches",
+          "description": "Next transition of the workflow if there is valid matches",
           "$ref": "#/definitions/transition"
         }
     },
@@ -930,7 +930,7 @@ There are found types of choices defined:
 | path |Path that selects the data input value to be matched | string | yes |
 | value |Matching value | string | yes |
 | operator |Data Input comparator | string | yes |
-| [transition](#Transitions) |Transition Definition if there is valid matches | string | yes |
+| [transition](#Transitions) |Next transition of the workflow if there is valid matches | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -958,7 +958,7 @@ There are found types of choices defined:
             }
         },
         "transition": {
-          "description": "Transition definition if there is valid matches",
+          "description": "Next transition of the workflow if there is valid matches",
           "$ref": "#/definitions/transition"
         }
     },
@@ -976,7 +976,7 @@ There are found types of choices defined:
 | path |Path that selects the data input value to be matched | string | yes |
 | value |Matching value | string | yes |
 | operator |Data Input comparator | string | yes |
-| [transition](#Transitions) |Transition Definition if there is valid matches | string | yes |
+| [transition](#Transitions) |Next transition of the workflow if there is valid matches | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -1005,7 +1005,7 @@ There are found types of choices defined:
             }
         },
         "transition": {
-          "description": "Transition definition if there is valid matches",
+          "description": "Next transition of the workflow if there is valid matches",
           "$ref": "#/definitions/transition"
         }
     },
@@ -1026,7 +1026,7 @@ There are found types of choices defined:
 | [filter](#Filter-Definition) |State data filter | object | yes |
 | [loop](#Loop-Definition) |State loop information | object | yes |
 | [onError](#Error-Handling) |States error handling definitions | array | no |
-| [transition](#Transitions) |Transition Definition after the delay | string | yes (if end is set to false) |
+| [transition](#Transitions) |Next transition of the workflow after the delay | string | yes (if end is set to false) |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary> 
 
@@ -1073,7 +1073,7 @@ There are found types of choices defined:
             }
         },
         "transition": {
-          "description": "Transition definition after the delay",
+          "description": "Next transition of the workflow after the delay",
           "$ref": "#/definitions/transition"
         }
     },
@@ -1108,7 +1108,7 @@ Delay state simple waits for a certain amount of time before transitioning to a 
 | [filter](#Filter-Definition) |State data filter | object | yes |
 | [loop](#Loop-Definition) |State loop behavior | object | yes |
 | [onError](#Error-Handling) |States error handling definitions | array | no |
-| [transition](#Transitions) |Transition Definition after all branches have completed execution | string | yes (if end is set to false) |
+| [transition](#Transitions) |Next transition of the workflow after all branches have completed execution | string | yes (if end is set to false) |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -1159,7 +1159,7 @@ Delay state simple waits for a certain amount of time before transitioning to a 
             }
         },
         "transition": {
-          "description": "Transition definition after all branches have completed execution",
+          "description": "Next transition of the workflow after all branches have completed execution",
           "$ref": "#/definitions/transition"
         }
     },
@@ -1257,7 +1257,7 @@ true, the branches parallel parent state must wait for this branch to finish bef
 | [filter](#Filter-Definition) |State data filter | object | yes |
 | [loop](#Loop-Definition) |State loop information | object | yes |
 | [onError](#State-Exception-Handling) |States error handling definitions | array | no |
-| [transition](#Transitions) |Transition Definition after subflow has completed | string | yes (if end is set to false) |
+| [transition](#Transitions) |Next transition of the workflow after subflow has completed | string | yes (if end is set to false) |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -1309,7 +1309,7 @@ true, the branches parallel parent state must wait for this branch to finish bef
            }
         },
         "transition": {
-          "description": "Transition definition after subflow has completed",
+          "description": "Next transition of the workflow after subflow has completed",
           "$ref": "#/definitions/transition"
         }
     },

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -257,7 +257,7 @@ see the [Error Handling section](#Error-Handling).
 | --- | --- | --- | --- |
 | errorExpression | Boolean expression to match one or more errors | string |yes |
 | [filter](#Filter-Definition) |Error data filter | object | yes |
-| nextState |State to transition to if errors expressed in errorExpression are matched | string | yes |
+| [transition](#Transitions) |Transition definition when errors expressed in errorExpression are matched | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -274,13 +274,12 @@ see the [Error Handling section](#Error-Handling).
       "$ref": "#/definitions/filter",
       "description": "Error data filter"
     },
-    "nextState": {
-      "type": "string",
-      "description": "State to transition to if errors expressed in errorExpression are matched",
-      "minLength": 1
+    "transition": {
+      "description": "Transition definition when errors expressed in errorExpression are matched",
+      "$ref": "#/definitions/transition"
     }
   },
-  "required": ["errorExpression", "nextState"]
+  "required": ["errorExpression", "transition"]
 }
 ```
 
@@ -390,7 +389,7 @@ Event state can hold one or more events definitions, so let's define those:
 | actionMode |Specifies if functions are executed in sequence of parallel | string | no |
 | [actions](#Action-Definition) |Array of actions | array | yes |
 | [filter](#Filter-Definition) |Event data filter | object | yes |
-| [nextState](#Transitions) |State to transition to after all the actions for the matching event have been successfully executed | string | yes |
+| [transition](#Transitions) |Transition definition after all the actions for the matching event have been successfully executed | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -423,12 +422,12 @@ Event state can hold one or more events definitions, so let's define those:
         "filter": {
           "$ref": "#/definitions/filter"
         },
-        "nextState": {
-            "type": "string",
-            "description": "State to transition to after all the actions for the matching event have been successfully executed"
+        "transition": {
+          "description": "Transition definition after all the actions for the matching event have been successfully executed",
+          "$ref": "#/definitions/transition"
         }
     },
-    "required": ["condition", "actions", "nextState"]
+    "required": ["condition", "actions", "transition"]
 }
 ```
 
@@ -436,7 +435,7 @@ Event state can hold one or more events definitions, so let's define those:
 
 The event expression attribute is used to associate this event state with one or more trigger events. 
 
-Note that each event definition has a "nextState" property, which is used to identify the state which 
+Note that each event definition has a "transition" property, which is used to identify the state which 
 should get triggered after this event completes.
 
 Each event state's event definition includes one or more actions. Let's define these actions now:
@@ -571,7 +570,7 @@ as well as define parameters (key/value pairs).
 | match |Result matching value | string | yes |
 | interval |Interval value for retry (ISO 8601 repeatable format). For example: "R5/PT15M" (Starting from now repeat 5 times with 15 minute intervals)| integer | no |
 | max |Max retry value | integer | no |
-| [nextState](#Transitions) |State to transition to when exceeding max limit | string | yes |
+| [transition](#Transitions) |Transition Definition when exceeding max limit | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -594,12 +593,12 @@ as well as define parameters (key/value pairs).
             "minimum": 0,
             "description": "Specifies the max retry"
         },
-        "nextState": {
-            "type": "string",
-            "description": "State to transition to when exceeding max limit"
+        "transition": {
+          "description": "Transition definition when exceeding max limit",
+          "$ref": "#/definitions/transition"
         }
     },
-    "required": ["match", "nextState"]
+    "required": ["match", "transition"]
 }
 ```
 
@@ -618,7 +617,7 @@ as well as define parameters (key/value pairs).
 | [filter](#Filter-Definition) |State data filter | object | yes |
 | [loop](#Loop-Definition) |State loop information | object | yes |
 | [onError](#Error-Handling) |States error handling definitions | array | no |
-| [nextState](#Transitions) |State to transition to after all the actions have been successfully executed | string | yes (if end is set to false) |
+| [transition](#Transitions) |Transition definition after all the actions have been successfully executed | string | yes (if end is set to false) |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -673,9 +672,9 @@ as well as define parameters (key/value pairs).
                 "$ref": "#/definitions/error"
             }
         },
-        "nextState": {
-            "type": "string",
-            "description": "State to transition to after all the actions have been successfully executed"
+        "transition": {
+          "description": "Transition definition after all the actions have been successfully executed",
+          "$ref": "#/definitions/transition"
         }
     },
     "if": {
@@ -687,7 +686,7 @@ as well as define parameters (key/value pairs).
       "required": ["name", "type", "actionMode", "actions"]
     },
     "else": {
-      "required": ["name", "type", "actionMode", "actions", "nextState"]
+      "required": ["name", "type", "actionMode", "actions", "transition"]
     }
 }
 ```
@@ -809,7 +808,7 @@ There are found types of choices defined:
 | path |Path that selects the data input value to be matched | string | yes |
 | value |Matching value | string | yes |
 | operator |Data Input comparator | string | yes |
-| [nextState](#Transitions) |State to transition to if there is valid match(es) | string | yes |
+| [transition](#Transitions) |Transition Definition if there is valid matches | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -831,12 +830,12 @@ There are found types of choices defined:
             "enum": ["Exists", "Equals", "LessThan", "LessThanEquals", "GreaterThan", "GreaterThanEquals"],
             "description": "Specifies how data input is compared with the value"
         },
-        "nextState": {
-            "type": "string",
-            "description": "Specifies the name of the next state to transition to if there is a value match"
+        "transition": {
+          "description": "Transition definition if there is valid matches",
+          "$ref": "#/definitions/transition"
         }
     },
-    "required": ["path", "value", "operator", "nextState"]
+    "required": ["path", "value", "operator", "transition"]
 }
 ```
 
@@ -850,7 +849,7 @@ There are found types of choices defined:
 | path |Path that selects the data input value to be matched | string | yes |
 | value |Matching value | string | yes |
 | operator |Data Input comparator | string | yes |
-| [nextState](#Transitions) |State to transition to if there is valid match(es) | string | yes |
+| [transition](#Transitions) |Transition Definition if there is valid matches | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -878,12 +877,12 @@ There are found types of choices defined:
                 }
             }
         },
-        "nextState": {
-            "type": "string",
-            "description": "Specifies the name of the next state to transition to if there is a value match"
+        "transition": {
+          "description": "Transition definition if there is valid matches",
+          "$ref": "#/definitions/transition"
         }
     },
-    "required": ["and", "path", "value", "operator", "nextState"]
+    "required": ["and", "path", "value", "operator", "transition"]
 }
 ```
 
@@ -897,7 +896,7 @@ There are found types of choices defined:
 | path |Path that selects the data input value to be matched | string | yes |
 | value |Matching value | string | yes |
 | operator |Data Input comparator | string | yes |
-| [nextState](#Transitions) |State to transition to if there is valid match(es) | string | yes |
+| [transition](#Transitions) |Transition Definition if there is valid matches | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -924,12 +923,12 @@ There are found types of choices defined:
                 }
             }
         },
-        "nextState": {
-            "type": "string",
-            "description": "Specifies the name of the next state to transition to if there is a value match"
+        "transition": {
+          "description": "Transition definition if there is valid matches",
+          "$ref": "#/definitions/transition"
         }
     },
-    "required": ["not", "path", "value", "operator", "nextState"]
+    "required": ["not", "path", "value", "operator", "transition"]
 }
 ```
 
@@ -943,7 +942,7 @@ There are found types of choices defined:
 | path |Path that selects the data input value to be matched | string | yes |
 | value |Matching value | string | yes |
 | operator |Data Input comparator | string | yes |
-| [nextState](#Transitions) |State to transition to if there is valid match(es) | string | yes |
+| [transition](#Transitions) |Transition Definition if there is valid matches | string | yes |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -971,12 +970,12 @@ There are found types of choices defined:
                 }                              
             }
         },
-        "nextState": {
-            "type": "string",
-            "description": "Specifies the name of the next state to transition to if there is a value match"
+        "transition": {
+          "description": "Transition definition if there is valid matches",
+          "$ref": "#/definitions/transition"
         }
     },
-    "required": ["or",  "path", "value", "operator", "nextState"]
+    "required": ["or",  "path", "value", "operator", "transition"]
 }
 ```
 </details>
@@ -993,7 +992,7 @@ There are found types of choices defined:
 | [filter](#Filter-Definition) |State data filter | object | yes |
 | [loop](#Loop-Definition) |State loop information | object | yes |
 | [onError](#Error-Handling) |States error handling definitions | array | no |
-| [nextState](#Transitions) |State to transition to after the delay | string | yes (if end is set to false) |
+| [transition](#Transitions) |Transition Definition after the delay | string | yes (if end is set to false) |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary> 
 
@@ -1039,9 +1038,9 @@ There are found types of choices defined:
                 "$ref": "#/definitions/error"
             }
         },
-        "nextState": {
-            "type": "string",
-            "description": "Name of the next state to transition to after the delay"
+        "transition": {
+          "description": "Transition definition after the delay",
+          "$ref": "#/definitions/transition"
         }
     },
     "if": {
@@ -1053,7 +1052,7 @@ There are found types of choices defined:
       "required": ["name", "type", "timeDelay", "end"]
     },
     "else": {
-      "required": ["name", "type", "timeDelay", "nextState"]
+      "required": ["name", "type", "timeDelay", "transition"]
     }
 }
 ```
@@ -1075,7 +1074,7 @@ Delay state simple waits for a certain amount of time before transitioning to a 
 | [filter](#Filter-Definition) |State data filter | object | yes |
 | [loop](#Loop-Definition) |State loop behavior | object | yes |
 | [onError](#Error-Handling) |States error handling definitions | array | no |
-| [nextState](#Transitions) |State to transition to after all branches have completed execution | string | yes (if end is set to false) |
+| [transition](#Transitions) |Transition Definition after all branches have completed execution | string | yes (if end is set to false) |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -1125,9 +1124,9 @@ Delay state simple waits for a certain amount of time before transitioning to a 
                 "$ref": "#/definitions/error"
             }
         },
-        "nextState": {
-            "type": "string",
-            "description": "Specifies the name of the next state to transition to after all branches have completed execution"
+        "transition": {
+          "description": "Transition definition after all branches have completed execution",
+          "$ref": "#/definitions/transition"
         }
     },
     "if": {
@@ -1139,7 +1138,7 @@ Delay state simple waits for a certain amount of time before transitioning to a 
       "required": ["name", "type", "branches"]
     },
     "else": {
-      "required": ["name", "type", "branches", "nextState"]
+      "required": ["name", "type", "branches", "transition"]
     }
 }
 ```
@@ -1224,7 +1223,7 @@ true, the branches parallel parent state must wait for this branch to finish bef
 | [filter](#Filter-Definition) |State data filter | object | yes |
 | [loop](#Loop-Definition) |State loop information | object | yes |
 | [onError](#State-Exception-Handling) |States error handling definitions | array | no |
-| [nextState](#Transitions) |State to transition to after subflow has completed | string | yes (if end is set to false) |
+| [transition](#Transitions) |Transition Definition after subflow has completed | string | yes (if end is set to false) |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -1275,9 +1274,9 @@ true, the branches parallel parent state must wait for this branch to finish bef
                 "$ref": "#/definitions/error"
            }
         },
-        "nextState": {
-            "type": "string",
-            "description": "State to transition to after subflow has completed."
+        "transition": {
+          "description": "Transition definition after subflow has completed",
+          "$ref": "#/definitions/transition"
         }
     },
     "if": {
@@ -1289,7 +1288,7 @@ true, the branches parallel parent state must wait for this branch to finish bef
       "required": ["name", "type", "workflowId"]
     },
     "else": {
-      "required": ["name", "type", "workflowId", "nextState"]
+      "required": ["name", "type", "workflowId", "transition"]
     }
 }
 ```
@@ -1435,9 +1434,13 @@ Here is an example of an Operation state which sends a confirmation email for ea
 ### Transitions
 
 Serverless workflow states can have one or more incoming and outgoing transitions (from/to other states).
-Each state has a "nextState" property which is a string value that determines which 
-state to transition to. Implementers can choose to use the states "name" string property
-for determining the next state, however we realize that in most cases this is not an
+Each state has a "transition" definition that is used to determines which 
+state to transition to next. 
+
+To define a transition, set the "nextState" property in your transition definitions.
+
+Implementers can choose to use the states "name" string property
+for determining the transition, however we realize that in most cases this is not an
 optimal solution that can lead to ambiguity. This is why each state also include an "id"
 property. Implementers can choose their own id generation strategy to populate the id property
 for each of the states and use it as the unique state identifier that is to be used as the "nextState" value. 
@@ -1446,6 +1449,65 @@ So the options for next state transitions are:
 * Use the state name property
 * Use the state id property
 * Use a combination of name and id properties
+
+#### Restricting Transitions based on state output
+
+In addition to specifying the "nextState" property a transition also defines a "condition" which must 
+evaluate to true for the transition to happen. Having this data-based restriction capabilities can help 
+ stop transitions within workflow execution that can have serious and harmful business impacts.
+
+State Transitions have access to the states data output. Conditions 
+can define an expression against the states output data to make sure that this transition only happens 
+if the expression evaluates to true.
+
+Here is an example of a restricted transition which only allows transition to the "highRiskState" if the 
+output of the state to transition from includes an user with the title "MANAGER".
+
+```json
+{  
+   "startsAt": "lowRiskState",
+   "states":[  
+      {  
+         "name":"lowRiskState",
+         "type":"OPERATION",
+         "actionMode":"Sequential",
+         "actions":[  
+          {  
+            "function":{
+               "name": "doLowRistOperation",
+               "resource": "functionResourse"
+            }
+          }
+         ],
+         "transition": {
+            "nextState":"highRiskState",
+            "condition": {
+               "expressionLanguage": "spel",
+               "body": "#jsonPath(stateOutputData,'$..user.title') eq 'MANAGER'"
+            }
+         }
+      },
+      {  
+         "name":"highRiskState",
+         "type":"OPERATION",
+         "end":true,
+         "actionMode":"Sequential",
+         "actions":[  
+            {  
+              "function":{
+                "name": "doHighRistOperation",
+                "resource": "functionResourse"
+              }
+           }
+         ]
+      }
+   ]
+}
+```
+
+Implementers should decide how to handle data-base transitions which return false (do not proceed).
+The default should be that if this happens workflow execution should halt and a detailed message
+ on why the transition failed should be provided.
 
 ### Information Passing
 
@@ -1560,10 +1622,14 @@ Let's take a look at a small example:
               "resultPath": "$.trace",
               "outputPath": "$.stateerror"
             },
-            "nextState": "afterErrorState"
+            "transition": {
+              "nextState": "afterErrorState"
+            }
           }
        ],
-       "nextState":"doSomethingElse"
+       "transition": {
+          "nextState":"doSomethingElse"
+       }
     },
     ...
   ]
@@ -1592,7 +1658,9 @@ workflow definition. Let's take a look:
          "resultPath": "$.trace",
          "outputPath": "$.stateerror"
        },
-       "nextState": "afterErrorState"
+       "transition": {
+          "nextState": "afterErrorState"
+       }
      }
   ],
   "states": [
@@ -1609,7 +1677,9 @@ workflow definition. Let's take a look:
              }
           }
        ],
-       "nextState":"doSomethingElse"
+       "transition": {
+          "nextState": "doSomethingElse"
+       }
     },
     {  
        "name":"HandleErrors2",
@@ -1624,7 +1694,9 @@ workflow definition. Let's take a look:
              }
           }
        ],
-       "nextState":"doSomethingElse"
+       "transition": {
+          "nextState": "doSomethingElse"
+       }
     },
     ...
   ]


### PR DESCRIPTION
This pr updates state transitions definition. 
Instead of just having "nextState", this adds a "transition" object with two properties:
"nextState" and "condition" (optional)

The first one works as before, however "condition" allows users to restrict/guard transitions by evaluating the states data output.

This is important so that we can prevent harmful transitions from happening.
Also this gives the ability to in future secure transitions etc.

An example is given in the spec description

This also fixes some existing examples json.