### PR TITLE
Action definitions - externalizing actions

### DIFF
--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -255,10 +255,6 @@
           "type": "string",
           "description": "Action unique name"
         },
-        "group": {
-          "type": "string",
-          "description": "Action group name"
-        },
         "function": {
           "description": "Specifies the function that must be invoked",
           "$ref": "#/definitions/function"
@@ -277,8 +273,7 @@
       },
       "required": [
         "name",
-        "function",
-        "group"
+        "function"
       ]
     },
     "retry": {

--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -53,6 +53,14 @@
         "$ref": "#/definitions/triggerevent"
       }
     },
+    "actionDefs": {
+      "type": "array",
+      "description": "Action Definitions",
+      "items": {
+        "type": "object",
+        "$ref": "#/definitions/action"
+      }
+    },
     "states": {
       "type": "array",
       "description": "State Definitions",
@@ -219,10 +227,10 @@
         },
         "actions": {
           "type": "array",
-          "description": "Action Definitions",
+          "description": "String array containing the defined action group names to be executed. Groups are executed in order defined.",
+          "default": [""],
           "items": {
-            "type": "object",
-            "$ref": "#/definitions/action"
+            "type": "string"
           }
         },
         "transition": {
@@ -243,6 +251,14 @@
     "action": {
       "type": "object",
       "properties": {
+        "name": {
+          "type": "string",
+          "description": "Action unique name"
+        },
+        "group": {
+          "type": "string",
+          "description": "Action group name"
+        },
         "function": {
           "description": "Specifies the function that must be invoked",
           "$ref": "#/definitions/function"
@@ -260,7 +276,9 @@
         }
       },
       "required": [
-        "function"
+        "name",
+        "function",
+        "group"
       ]
     },
     "retry": {
@@ -537,10 +555,10 @@
           },
           "actions": {
             "type": "array",
-            "description": "Actions Definitions",
+            "description": "String array containing the defined action group names to be executed. Groups are executed in order defined.",
+            "default": [""],
             "items": {
-              "type": "object",
-              "$ref": "#/definitions/action"
+              "type": "string"
             }
           },
           "loop": {

--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -45,17 +45,17 @@
       "type": "string",
       "description": "Default expression language to be used throughout the workflow definition"
     },
-    "triggers": {
+    "triggerDefs": {
       "type": "array",
-      "description": "Workflow Triggers",
+      "description": "Workflow Trigger Definitions",
       "items": {
         "type": "object",
         "$ref": "#/definitions/triggerevent"
       }
     },
-    "actions": {
+    "actionDefs": {
       "type": "array",
-      "description": "Workflow Actions",
+      "description": "Workflow Action Definitions",
       "items": {
         "type": "object",
         "$ref": "#/definitions/action"
@@ -555,7 +555,7 @@
           },
           "actions": {
             "type": "array",
-            "description": "String array containing action group names to be executed. Actions are executed in order defined.",
+            "description": "String array containing action names to be executed. Actions are executed in order defined.",
             "default": [""],
             "items": {
               "type": "string"

--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -45,17 +45,17 @@
       "type": "string",
       "description": "Default expression language to be used throughout the workflow definition"
     },
-    "triggerDefs": {
+    "triggers": {
       "type": "array",
-      "description": "Trigger Definitions",
+      "description": "Workflow Triggers",
       "items": {
         "type": "object",
         "$ref": "#/definitions/triggerevent"
       }
     },
-    "actionDefs": {
+    "actions": {
       "type": "array",
-      "description": "Action Definitions",
+      "description": "Workflow Actions",
       "items": {
         "type": "object",
         "$ref": "#/definitions/action"
@@ -227,7 +227,7 @@
         },
         "actions": {
           "type": "array",
-          "description": "String array containing the defined action group names to be executed. Groups are executed in order defined.",
+          "description": "String array containing action names to be executed. Actions are executed in order defined.",
           "default": [""],
           "items": {
             "type": "string"
@@ -555,7 +555,7 @@
           },
           "actions": {
             "type": "array",
-            "description": "String array containing the defined action group names to be executed. Groups are executed in order defined.",
+            "description": "String array containing action group names to be executed. Actions are executed in order defined.",
             "default": [""],
             "items": {
               "type": "string"

--- a/workflow/spec/spec-examples.md
+++ b/workflow/spec/spec-examples.md
@@ -109,22 +109,25 @@ output, which then becomes the data output of the workflow itself (as it is the 
    "name": "Greeting Workflow",
    "description": "Greet Someone",
    "startsAt": "Greet",
+   "actionDefs": [
+      {
+        "name": "Greet Action",
+        "group": "Greetings",
+        "function": {
+            "name": "greetingFunction",
+            "resource": "functionResourse",
+            "parameters": {
+               "name": "$.greet.name"
+            }
+         }
+       }
+   ],
    "states":[  
       {  
          "name":"Greet",
          "type":"OPERATION",
          "actionMode":"SEQUENTIAL",
-         "actions":[  
-            {  
-               "function":{
-                  "name": "greetingFunction",
-                  "resource": "functionResourse",
-                  "parameters": {
-                    "name": "$.greet.name"
-                  }
-               }
-            }
-         ],
+         "actions":["Greetings"],
          "filter": {
             "resultPath": "$.out",
             "outputPath": "$.out.payload.greeting"
@@ -175,22 +178,25 @@ The state filter is then used to only return the results of the solved math expr
    "name": "Solve Math Problems Workflow",
    "description": "Solve math problems",
    "startsAt": "Solve",
+   "actionDefs": [
+     {
+        "name": "Math Action",
+        "group": "Math",
+        "function": {
+           "name": "solveMathExpressionFunction",
+           "resource": "functionResourse",
+           "parameters": {
+             "expression": "$."
+           }
+        }
+       }
+   ],
    "states":[  
       {  
          "name":"Solve",
          "type":"OPERATION",
          "actionMode":"SEQUENTIAL",
-         "actions":[  
-            {  
-               "function":{
-                  "name": "solveMathExpressionFunction",
-                  "resource": "functionResourse",
-                  "parameters": {
-                    "expression": "$."
-                  }
-               }
-            }
-         ],
+         "actions":["Math"],
          "loop": {
              "inputCollection": "$.expressions",
              "outputCollection": "$.answers"
@@ -298,6 +304,19 @@ If the applicants age is over 18 we start the application (subflow state). Other
    "name": "Applicant Request Decision Workflow",
    "description": "Determine if applicant request is valid",
    "startsAt": "CheckApplication",
+   "actionDefs": [
+     {
+        "name": "Reject Order Action",
+        "group": "OrderRejection",
+        "function": {
+           "name": "sendRejectionEmailFunction",
+           "resource": "functionResourse",
+           "parameters": {
+             "applicant": "$.applicant"
+           }
+        }
+     }
+   ],
    "states":[  
       {  
          "name":"CheckApplication",
@@ -332,17 +351,7 @@ If the applicants age is over 18 we start the application (subflow state). Other
         "name":"RejectApplication",
         "type":"OPERATION",
         "actionMode":"SEQUENTIAL",
-        "actions":[  
-           {  
-              "function":{
-                 "name": "sendRejectionEmailFunction",
-                 "resource": "functionResourse",
-                 "parameters": {
-                   "applicant": "$.applicant"
-                 }
-              }
-           }
-        ],
+        "actions":["OrderRejection"],
         "end": true
     }
    ]
@@ -385,22 +394,25 @@ The data output of the workflow contains the information of the exception caught
    "name": "Provision Orders",
    "description": "Provision Orders and handle errors thrown",
    "startsAt": "ProvisionOrder",
+   "actionDefs": [
+    {
+       "name": "Provision Order Action",
+       "group": "Provisioning",
+       "function":{
+          "name": "provisionOrderFunction",
+          "resource": "functionResourse",
+          "parameters": {
+            "order": "$.order"
+          }
+       }
+    }
+   ],
    "states":[  
       {  
         "name":"ProvisionOrder",
         "type":"OPERATION",
         "actionMode":"SEQUENTIAL",
-        "actions":[  
-           {  
-              "function":{
-                 "name": "provisionOrderFunction",
-                 "resource": "functionResourse",
-                 "parameters": {
-                   "order": "$.order"
-                 }
-              }
-           }
-        ],
+        "actions":["Provisioning"],
         "filter": {
            "resultPath": "$.exception"
         },

--- a/workflow/spec/spec-examples.md
+++ b/workflow/spec/spec-examples.md
@@ -394,7 +394,7 @@ The data output of the workflow contains the information of the exception caught
    "actionDefs": [
     {
        "name": "ProvisionOrderAction",
-       "function":{
+       "function": {
           "name": "provisionOrderFunction",
           "resource": "functionResourse",
           "parameters": {
@@ -508,7 +508,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
         "actionMode":"SEQUENTIAL",
         "actions":[  
            {  
-              "function":{
+              "function": {
                  "name": "submitJob",
                  "resource": "submitJobResource",
                  "parameters": {
@@ -555,7 +555,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
         "actionMode":"SEQUENTIAL",
         "actions":[  
            {  
-              "function":{
+              "function": {
                  "name": "checkJobStatus",
                  "resource": "checkJobStatusResource",
                  "parameters": {
@@ -600,7 +600,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
        "actionMode":"SEQUENTIAL",
        "actions":[  
           {  
-             "function":{
+             "function": {
                 "name": "reportJobSuceeded",
                 "resource": "reportJobSuceededResource",
                 "parameters": {
@@ -617,7 +617,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
       "actionMode":"SEQUENTIAL",
       "actions":[  
          {  
-            "function":{
+            "function": {
                "name": "reportJobFailed",
                "resource": "reportJobFailedResource",
                "parameters": {

--- a/workflow/spec/spec-examples.md
+++ b/workflow/spec/spec-examples.md
@@ -111,8 +111,7 @@ output, which then becomes the data output of the workflow itself (as it is the 
    "startsAt": "Greet",
    "actionDefs": [
       {
-        "name": "Greet Action",
-        "group": "Greetings",
+        "name": "GreetingAction",
         "function": {
             "name": "greetingFunction",
             "resource": "functionResourse",
@@ -127,7 +126,7 @@ output, which then becomes the data output of the workflow itself (as it is the 
          "name":"Greet",
          "type":"OPERATION",
          "actionMode":"SEQUENTIAL",
-         "actions":["Greetings"],
+         "actions":["GreetingAction"],
          "filter": {
             "resultPath": "$.out",
             "outputPath": "$.out.payload.greeting"
@@ -180,8 +179,7 @@ The state filter is then used to only return the results of the solved math expr
    "startsAt": "Solve",
    "actionDefs": [
      {
-        "name": "Math Action",
-        "group": "Math",
+        "name": "MathAction",
         "function": {
            "name": "solveMathExpressionFunction",
            "resource": "functionResourse",
@@ -196,7 +194,7 @@ The state filter is then used to only return the results of the solved math expr
          "name":"Solve",
          "type":"OPERATION",
          "actionMode":"SEQUENTIAL",
-         "actions":["Math"],
+         "actions":["MathAction"],
          "loop": {
              "inputCollection": "$.expressions",
              "outputCollection": "$.answers"
@@ -306,8 +304,7 @@ If the applicants age is over 18 we start the application (subflow state). Other
    "startsAt": "CheckApplication",
    "actionDefs": [
      {
-        "name": "Reject Order Action",
-        "group": "OrderRejection",
+        "name": "RejectOrderAction",
         "function": {
            "name": "sendRejectionEmailFunction",
            "resource": "functionResourse",
@@ -351,7 +348,7 @@ If the applicants age is over 18 we start the application (subflow state). Other
         "name":"RejectApplication",
         "type":"OPERATION",
         "actionMode":"SEQUENTIAL",
-        "actions":["OrderRejection"],
+        "actions":["RejectOrderAction"],
         "end": true
     }
    ]
@@ -396,8 +393,7 @@ The data output of the workflow contains the information of the exception caught
    "startsAt": "ProvisionOrder",
    "actionDefs": [
     {
-       "name": "Provision Order Action",
-       "group": "Provisioning",
+       "name": "ProvisionOrderAction",
        "function":{
           "name": "provisionOrderFunction",
           "resource": "functionResourse",
@@ -412,7 +408,7 @@ The data output of the workflow contains the information of the exception caught
         "name":"ProvisionOrder",
         "type":"OPERATION",
         "actionMode":"SEQUENTIAL",
-        "actions":["Provisioning"],
+        "actions":["ProvisionOrderAction"],
         "filter": {
            "resultPath": "$.exception"
         },

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -471,7 +471,7 @@ Incoming events are matched against the states condition parameter. If they matc
 | [condition](#Condition-Definition) |Condition consisting of Boolean operation of events that will trigger the event state | object | yes |
 | timeout |Time period to wait for the events in the condition (ISO 8601 format). For example: "PT15M" (wait 15 minutes), or "P2DT3H4M" (wait 2 days, 3 hours and 4 minutes)| string | no |
 | actionMode |Specifies if functions are executed in sequence of parallel | string | no |
-| actions |String array containing the defined action group names to be executed. Groups are executed in order defined. | array | yes |
+| actions |String array containing the defined action names to be executed. Actions are executed in order defined. | array | yes |
 | [filter](#Filter-Definition) |Event data filter | object | yes |
 | [transition](#Transitions) |Next transition of the workflow after all the actions for the matching event have been successfully executed | string | yes |
 
@@ -683,7 +683,7 @@ Defines Transitions from point A to point B in the serverless workflow. For more
 | type |State type | string | yes |
 | end |Is this state an end state | boolean | no |
 | actionMode |Should actions be executed sequentially or in parallel | string | yes |
-| actions |String array containing the defined action group names to be executed. Groups are executed in order defined. | array | yes |
+| actions |String array containing the defined action names to be executed. Actions are executed in order defined. | array | yes |
 | [filter](#Filter-Definition) |State data filter | object | yes |
 | [loop](#Loop-Definition) |State loop information | object | yes |
 | [onError](#Error-Handling) |States error handling definitions | array | no |


### PR DESCRIPTION
Actions are currently used within both event and operation states. As they are defined, same actions cannot be reused between these two states (have to be defined multiple times).

This pr externalizes actions into "actionDefs" section of the workflow (similar to triggerDefs).

Event and Operation states can then instead of defining each individual action reference a set of defined actions by their action name. 
