### PR TITLE
Updating transition definition - adding 'end' property

### DIFF
--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -121,11 +121,24 @@
           "type": "string",
           "description": "State to transition to next",
           "minLength": 1
+        },
+        "end": {
+          "type": "boolean",
+          "default": false,
+          "description": "Instead of transitioning to nextState, end workflow execution instead"
         }
       },
-      "required": [
-        "nextState"
-      ]
+      "if": {
+        "properties": {
+          "end": { "const": true }
+        }
+      },
+      "then": {
+        "required": ["end"]
+      },
+      "else": {
+        "required": ["nextState"]
+      }
     },
     "error": {
       "type": "object",

--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -125,7 +125,7 @@
         "end": {
           "type": "boolean",
           "default": false,
-          "description": "Instead of transitioning to nextState, end workflow execution instead"
+          "description": "Instead of transitioning to nextState, end workflow execution"
         }
       },
       "if": {

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -627,7 +627,7 @@ as well as define parameters (key/value pairs).
 | --- | --- | --- | --- |
 | [condition](#Condition-Definition) |Boolean expression evaluated against state's data output. Must evaluate to true for the transition to be valid. | object | no |
 | [nextState](#Transitions) |State to transition to next | string | yes |
-| end | Instead of transitioning to nextState, end workflow execution instead | boolean | no |
+| end | Instead of transitioning to nextState, end workflow execution | boolean | no |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -647,7 +647,7 @@ as well as define parameters (key/value pairs).
     "end": {
         "type": "boolean",
         "default": false,
-        "description": "Instead of transitioning to nextState, end workflow execution instead"
+        "description": "Instead of transitioning to nextState, end workflow execution"
     }
   },
   "if": {


### PR DESCRIPTION
It is actually really useful to be able to end workflow execution inside the transition definition. 
The pr includes two examples that you can look at to see why.