### PR TITLE
Reusable functions - referenced in actions

### DIFF
--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -45,12 +45,20 @@
       "type": "string",
       "description": "Default expression language to be used throughout the workflow definition"
     },
-    "triggerDefs": {
+    "triggers": {
       "type": "array",
-      "description": "Trigger Definitions",
+      "description": "Workflow event triggers",
       "items": {
         "type": "object",
         "$ref": "#/definitions/triggerevent"
+      }
+    },
+    "functions": {
+      "type": "array",
+      "description": "Workflow functions",
+      "items": {
+        "type": "object",
+        "$ref": "#/definitions/function"
       }
     },
     "states": {
@@ -243,9 +251,9 @@
     "action": {
       "type": "object",
       "properties": {
-        "function": {
-          "description": "Specifies the function that must be invoked",
-          "$ref": "#/definitions/function"
+        "functionref": {
+          "description": "References a reusable function definition to be invoked",
+          "$ref": "#/definitions/functionref"
         },
         "retry": {
           "type": "array",
@@ -260,16 +268,16 @@
         }
       },
       "required": [
-        "function"
+        "functionref"
       ]
     },
     "retry": {
       "type": "object",
       "description": "Retry Definition",
       "properties": {
-        "match": {
-          "type": "string",
-          "description": "Specifies the matching value for the result"
+        "condition": {
+          "description": "Boolean condition that matches against the function results. Must be evaluated to true for retry policy to trigger",
+          "$ref": "#/definitions/condition"
         },
         "interval": {
           "type": "string",
@@ -295,7 +303,8 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "Function name"
+            "description": "Function unique name",
+            "minLength": 1
           },
           "resource": {
             "type": "string",
@@ -303,7 +312,21 @@
           },
           "type": {
             "type": "string",
-            "description": "Type of function to implement. Implementors may define custom types here."
+            "description": "Type of function to implement. Can be defined by implementations"
+          }
+        },
+        "required": [
+          "name",
+          "resource"
+        ]
+      },
+      "functionref": {
+        "type": "object",
+        "description": "Function Reference",
+        "properties": {
+          "refname": {
+            "type": "string",
+            "desription": "Name of the referenced function"
           },
           "parameters": {
             "type": "object",
@@ -311,8 +334,7 @@
           }
         },
         "required": [
-          "name",
-          "type"
+          "refname"
         ]
       },
       "branch": {

--- a/workflow/spec/spec-examples.md
+++ b/workflow/spec/spec-examples.md
@@ -109,6 +109,12 @@ output, which then becomes the data output of the workflow itself (as it is the 
    "name": "Greeting Workflow",
    "description": "Greet Someone",
    "startsAt": "Greet",
+   "functions": [
+      {
+         "name": "greetingFunction",
+         "resource": "functionResourse"
+      }
+   ],
    "states":[  
       {  
          "name":"Greet",
@@ -116,9 +122,8 @@ output, which then becomes the data output of the workflow itself (as it is the 
          "actionMode":"SEQUENTIAL",
          "actions":[  
             {  
-               "function":{
-                  "name": "greetingFunction",
-                  "resource": "functionResourse",
+               "functionref": {
+                  "refname": "greetingFunction",
                   "parameters": {
                     "name": "$.greet.name"
                   }
@@ -175,6 +180,12 @@ The state filter is then used to only return the results of the solved math expr
    "name": "Solve Math Problems Workflow",
    "description": "Solve math problems",
    "startsAt": "Solve",
+   "functions": [
+       {
+          "name": "solveMathExpressionFunction",
+          "resource": "functionResourse"
+       }
+   ],
    "states":[  
       {  
          "name":"Solve",
@@ -182,9 +193,8 @@ The state filter is then used to only return the results of the solved math expr
          "actionMode":"SEQUENTIAL",
          "actions":[  
             {  
-               "function":{
-                  "name": "solveMathExpressionFunction",
-                  "resource": "functionResourse",
+               "functionref": {
+                  "refname": "solveMathExpressionFunction",
                   "parameters": {
                     "expression": "$."
                   }
@@ -298,6 +308,12 @@ If the applicants age is over 18 we start the application (subflow state). Other
    "name": "Applicant Request Decision Workflow",
    "description": "Determine if applicant request is valid",
    "startsAt": "CheckApplication",
+   "functions": [
+     {
+        "name": "sendRejectionEmailFunction",
+        "resource": "functionResourse"
+     }
+   ],
    "states":[  
       {  
          "name":"CheckApplication",
@@ -334,9 +350,8 @@ If the applicants age is over 18 we start the application (subflow state). Other
         "actionMode":"SEQUENTIAL",
         "actions":[  
            {  
-              "function":{
-                 "name": "sendRejectionEmailFunction",
-                 "resource": "functionResourse",
+              "functionref": {
+                 "refname": "sendRejectionEmailFunction",
                  "parameters": {
                    "applicant": "$.applicant"
                  }
@@ -385,6 +400,12 @@ The data output of the workflow contains the information of the exception caught
    "name": "Provision Orders",
    "description": "Provision Orders and handle errors thrown",
    "startsAt": "ProvisionOrder",
+   "functions": [
+      {
+         "name": "provisionOrderFunction",
+         "resource": "functionResourse"
+      }
+   ],
    "states":[  
       {  
         "name":"ProvisionOrder",
@@ -392,9 +413,8 @@ The data output of the workflow contains the information of the exception caught
         "actionMode":"SEQUENTIAL",
         "actions":[  
            {  
-              "function":{
-                 "name": "provisionOrderFunction",
-                 "resource": "functionResourse",
+              "functionref": {
+                 "refname": "provisionOrderFunction",
                  "parameters": {
                    "order": "$.order"
                  }
@@ -493,6 +513,24 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
    "name": "Job Monitoring",
    "description": "Monitor finished execution of a submitted job",
    "startsAt": "SubmitJob",
+   "functions": [
+     {
+       "name": "submitJob",
+       "resource": "submitJobResource"
+     },
+     {
+        "name": "checkJobStatus",
+        "resource": "checkJobStatusResource"
+     },
+     {
+        "name": "reportJobSuceeded",
+        "resource": "reportJobSuceededResource"
+     },
+     {
+        "name": "reportJobFailed",
+        "resource": "reportJobFailedResource"
+     }
+   ],
    "states":[  
       {  
         "name":"SubmitJob",
@@ -500,9 +538,8 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
         "actionMode":"SEQUENTIAL",
         "actions":[  
            {  
-              "function":{
-                 "name": "submitJob",
-                 "resource": "submitJobResource",
+              "functionref": {
+                 "refname": "submitJob",
                  "parameters": {
                    "name": "$.job.name"
                  }
@@ -547,9 +584,8 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
         "actionMode":"SEQUENTIAL",
         "actions":[  
            {  
-              "function":{
-                 "name": "checkJobStatus",
-                 "resource": "checkJobStatusResource",
+              "functionref": {
+                 "refname": "checkJobStatus",
                  "parameters": {
                    "name": "$.jobuid"
                  }
@@ -592,9 +628,8 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
        "actionMode":"SEQUENTIAL",
        "actions":[  
           {  
-             "function":{
-                "name": "reportJobSuceeded",
-                "resource": "reportJobSuceededResource",
+             "functionref": {
+                "refname": "reportJobSuceeded",
                 "parameters": {
                   "name": "$.jobuid"
                 }
@@ -609,9 +644,8 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
       "actionMode":"SEQUENTIAL",
       "actions":[  
          {  
-            "function":{
+            "functionref": {
                "name": "reportJobFailed",
-               "resource": "reportJobFailedResource",
                "parameters": {
                  "name": "$.jobuid"
                }

--- a/workflow/spec/spec-extending.md
+++ b/workflow/spec/spec-extending.md
@@ -32,6 +32,16 @@ So let's define a simple example workflow model and then add our custom extensio
 {  
    "name": "Simple Workflow",
    "startsAt": "FirstOperation",
+   "functions": [
+      {
+         "name": "firstFunction",
+         "type": "serverless"
+      },
+      {
+         "name": "secondFunction",
+         "type": "serverless"
+      }
+   ],
    "states":[  
       {  
          "name":"FirstOperation",
@@ -41,9 +51,8 @@ So let's define a simple example workflow model and then add our custom extensio
          "actions":[  
             {  
                "name": "callFirstFunction",
-               "function": {
-                  "name": "firstFunction",
-                  "type": "serverless"
+               "functionref": {
+                  "refname": "firstFunction"
                }
             }
          ],
@@ -59,9 +68,8 @@ So let's define a simple example workflow model and then add our custom extensio
          "actions":[  
               {  
                  "name": "callSecondFunction",
-                 "function": {
-                   "name": "secondFunction",
-                   "type": "serverless"
+                 "functionref": {
+                   "refname": "secondFunction"
                 }
               }
          ]


### PR DESCRIPTION
Functions are now defined similar to triggers and can be referenced within actions of event and operation states. 
Makes functions reusable between defined actions.
Functions are referenced via "functionref" property in actions. Function properties are defined inside functionref of actions.

Also this pr:
* changes "triggerDefs" to "triggers"
* renames retry definition "match" to "condition" so its a proper condition and not a string