### PR TITLE
YAML support for workflow definitions

### DIFF
--- a/workflow/spec/spec-examples.md
+++ b/workflow/spec/spec-examples.md
@@ -31,38 +31,71 @@ value of the "result" property. Since it is an end state, it's data output becom
 "Hello World!"
 ```
 
-#### Workflow JSON
+#### Workflow Definition
+
+<table>
+<tr>
+    <th>JSON</th>
+    <th>YAML</th>
+</tr>
+<tr>
+<td>
 
 ```json
 {  
-   "name": "Hello World Workflow",
-   "description": "Static Hello World",
-   "startsAt": "Hello",
-   "states":[  
-      {  
-         "name":"Hello",
-         "type":"RELAY",
-         "inject": {
-            "result": "Hello"
-         },
-         "transition": {
-           "nextState": "World"
-         }
-      },
-      {  
-         "name":"World",
-         "type":"RELAY",
-         "inject": {
-            "result": " World!"
-         },
-         "filter": {
-           "outputPath": "$.result"
-         },
-         "end": true 
-      }
-   ]
+"name": "Hello World Workflow",
+"description": "Static Hello World",
+"startsAt": "Hello",
+"states":[  
+  {  
+     "name":"Hello",
+     "type":"RELAY",
+     "inject": {
+        "result": "Hello"
+     },
+     "transition": {
+       "nextState": "World"
+     }
+  },
+  {  
+     "name":"World",
+     "type":"RELAY",
+     "inject": {
+        "result": " World!"
+     },
+     "filter": {
+       "outputPath": "$.result"
+     },
+     "end": true 
+  }
+]
 }
 ```
+</td>
+<td>
+
+```yaml
+name: Hello World Workflow
+description: Static Hello World
+startsAt: Hello
+states:
+- name: Hello
+  type: RELAY
+  inject:
+    result: Hello
+  transition:
+    nextState: World
+- name: World
+  type: RELAY
+  inject:
+    result: " World!"
+  filter:
+    outputPath: "$.result"
+  end: true
+```
+</td>
+</tr>
+</table>
 
 #### Worfklow Diagram
 
@@ -102,43 +135,79 @@ output, which then becomes the data output of the workflow itself (as it is the 
    "Welcome to Serverless Workflow, John!" 
 ```
 
-#### Workflow JSON
+#### Workflow Definition
+
+<table>
+<tr>
+    <th>JSON</th>
+    <th>YAML</th>
+</tr>
+<tr>
+<td>
 
 ```json
 {  
-   "name": "Greeting Workflow",
-   "description": "Greet Someone",
-   "startsAt": "Greet",
-   "functions": [
-      {
-         "name": "greetingFunction",
-         "resource": "functionResourse"
-      }
-   ],
-   "states":[  
-      {  
-         "name":"Greet",
-         "type":"OPERATION",
-         "actionMode":"SEQUENTIAL",
-         "actions":[  
-            {  
-               "functionref": {
-                  "refname": "greetingFunction",
-                  "parameters": {
-                    "name": "$.greet.name"
-                  }
-               }
-            }
-         ],
-         "filter": {
-            "resultPath": "$.out",
-            "outputPath": "$.out.payload.greeting"
-         },
-         "end": true
-      }
-   ]
+"name": "Greeting Workflow",
+"description": "Greet Someone",
+"startsAt": "Greet",
+"functions": [
+  {
+     "name": "greetingFunction",
+     "resource": "functionResourse"
+  }
+],
+"states":[  
+  {  
+     "name":"Greet",
+     "type":"OPERATION",
+     "actionMode":"SEQUENTIAL",
+     "actions":[  
+        {  
+           "functionref": {
+              "refname": "greetingFunction",
+              "parameters": {
+                "name": "$.greet.name"
+              }
+           }
+        }
+     ],
+     "filter": {
+        "resultPath": "$.out",
+        "outputPath": "$.out.payload.greeting"
+     },
+     "end": true
+  }
+]
 }
 ```
+</td>
+<td>
+
+```yaml
+name: Greeting Workflow
+description: Greet Someone
+startsAt: Greet
+functions:
+- name: greetingFunction
+  resource: functionResourse
+states:
+- name: Greet
+  type: OPERATION
+  actionMode: SEQUENTIAL
+  actions:
+  - functionref:
+      refname: greetingFunction
+      parameters:
+        name: "$.greet.name"
+  filter:
+    resultPath: "$.out"
+    outputPath: "$.out.payload.greeting"
+  end: true
+```
+</td>
+</tr>
+</table>
+
 #### Worfklow Diagram
 
 <p align="center">
@@ -165,53 +234,95 @@ and returns its result.
 Results of all mathe expressions are accumulated into the data output of the ForEach state which become the final
 result of the workflow execution.
 
-#### Workflow JSON
+#### Workflow Definition
+
+<table>
+<tr>
+    <th>JSON</th>
+    <th>YAML</th>
+</tr>
+<tr>
+<td>
 
 ```json
 {  
-   "name": "Solve Math Problems Workflow",
-   "description": "Solve math problems",
-   "startsAt": "Solve",
-   "functions": [
-       {
-          "name": "solveMathExpressionFunction",
-          "resource": "functionResourse"
+"name": "Solve Math Problems Workflow",
+"description": "Solve math problems",
+"startsAt": "Solve",
+"functions": [
+{
+  "name": "solveMathExpressionFunction",
+  "resource": "functionResourse"
+}
+],
+"states":[  
+{   
+ "name":"Solve",
+ "type":"FOREACH",
+ "inputCollection": "$.expressions",
+ "inputParameter": "$.singleexpression",
+ "outputCollection": "$.results",
+ "startsAt": "GetResults",
+ "states": [
+{  
+    "name":"GetResults",
+    "type":"OPERATION",
+    "actionMode":"SEQUENTIAL",
+    "actions":[  
+       {  
+          "functionref": {
+             "refname": "solveMathExpressionFunction",
+             "parameters": {
+               "expression": "$.singleexpression"
+             }
+          }
        }
-   ],
-   "states":[  
-      {   
-         "name":"Solve",
-         "type":"FOREACH",
-         "inputCollection": "$.expressions",
-         "inputParameter": "$.singleexpression",
-         "outputCollection": "$.results",
-         "startsAt": "GetResults",
-         "states": [
-            {  
-                "name":"GetResults",
-                "type":"OPERATION",
-                "actionMode":"SEQUENTIAL",
-                "actions":[  
-                   {  
-                      "functionref": {
-                         "refname": "solveMathExpressionFunction",
-                         "parameters": {
-                           "expression": "$.singleexpression"
-                         }
-                      }
-                   }
-                ],
-                "end": true
-            }
-         ],
-         "filter": {
-            "outputPath": "$.results"
-         },
-         "end": true
-      }
-   ]
+    ],
+    "end": true
+}
+ ],
+ "filter": {
+    "outputPath": "$.results"
+ },
+ "end": true
+}
+]
 }
 ```
+</td>
+<td>
+
+```yaml
+name: Solve Math Problems Workflow
+description: Solve math problems
+startsAt: Solve
+functions:
+- name: solveMathExpressionFunction
+  resource: functionResourse
+states:
+- name: Solve
+  type: FOREACH
+  inputCollection: "$.expressions"
+  inputParameter: "$.singleexpression"
+  outputCollection: "$.results"
+  startsAt: GetResults
+  states:
+  - name: GetResults
+    type: OPERATION
+    actionMode: SEQUENTIAL
+    actions:
+    - functionref:
+        refname: solveMathExpressionFunction
+        parameters:
+          expression: "$.singleexpression"
+    end: true
+  filter:
+    outputPath: "$.results"
+  end: true
+```
+</td>
+</tr>
+</table>
 
 #### Worfklow Diagram
 
@@ -228,50 +339,90 @@ Note that the waitForCompletion flag is set to "false" so as soon as the "ShortD
 the workflow complete execution. If waitForCompletion was set to true, the workflow would complete after both
 of the branches are done.
 
-#### Workflow JSON
+#### Workflow Definition
+
+<table>
+<tr>
+    <th>JSON</th>
+    <th>YAML</th>
+</tr>
+<tr>
+<td>
 
 ```json
 {  
-   "name": "Parallel Execution Workflow",
-   "description": "Executes two branches in parallel",
-   "startsAt": "ParallelExec",
-   "states":[  
-      {  
-         "name":"ParallelExec",
-         "type":"PARALLEL",
-         "branches": [
+"name": "Parallel Execution Workflow",
+"description": "Executes two branches in parallel",
+"startsAt": "ParallelExec",
+"states":[  
+  {  
+     "name":"ParallelExec",
+     "type":"PARALLEL",
+     "branches": [
+        {
+          "name": "Branch1",
+          "startsAt": "ShortDelay",
+          "states": [
             {
-              "name": "Branch1",
-              "startsAt": "ShortDelay",
-              "states": [
-                {
-                    "name":"ShortDelay",
-                     "type":"DELAY",
-                     "timeDelay": "PT15S",
-                     "end": true
-                }
-              ],
-              "waitForCompletion": false
-            },
-            {
-              "name": "Branch2",
-              "startsAt": "LongDelay",
-              "states": [
-                 {
-                     "name":"LongDelay",
-                      "type":"DELAY",
-                      "timeDelay": "PT2M",
-                      "end": true
-                 }      
-              ],
-              "waitForCompletion": false
+                "name":"ShortDelay",
+                 "type":"DELAY",
+                 "timeDelay": "PT15S",
+                 "end": true
             }
-         ],
-         "end": true
-      }
-   ]
+          ],
+          "waitForCompletion": false
+        },
+        {
+          "name": "Branch2",
+          "startsAt": "LongDelay",
+          "states": [
+             {
+                 "name":"LongDelay",
+                  "type":"DELAY",
+                  "timeDelay": "PT2M",
+                  "end": true
+             }      
+          ],
+          "waitForCompletion": false
+        }
+     ],
+     "end": true
+  }
+]
 }
 ```
+</td>
+<td>
+
+```yaml
+name: Parallel Execution Workflow
+description: Executes two branches in parallel
+startsAt: ParallelExec
+states:
+- name: ParallelExec
+  type: PARALLEL
+  branches:
+  - name: Branch1
+    startsAt: ShortDelay
+    states:
+    - name: ShortDelay
+      type: DELAY
+      timeDelay: PT15S
+      end: true
+    waitForCompletion: false
+  - name: Branch2
+    startsAt: LongDelay
+    states:
+    - name: LongDelay
+      type: DELAY
+      timeDelay: PT2M
+      end: true
+    waitForCompletion: false
+  end: true
+```
+</td>
+</tr>
+</table>
 
 #### Worfklow Diagram
 
@@ -300,7 +451,15 @@ We use the switch state with two choices to determine if the application should 
 If the applicants age is over 18 we start the application (subflow state). Otherwise the workflow notifies the 
  applicant of the rejection. 
 
-#### Workflow JSON
+#### Workflow Definition
+
+<table>
+<tr>
+    <th>JSON</th>
+    <th>YAML</th>
+</tr>
+<tr>
+<td>
 
 ```json
 {  
@@ -362,8 +521,51 @@ If the applicants age is over 18 we start the application (subflow state). Other
         "end": true
     }
    ]
-}
+} 
 ```
+</td>
+<td>
+
+```yaml
+name: Applicant Request Decision Workflow
+description: Determine if applicant request is valid
+startsAt: CheckApplication
+functions:
+- name: sendRejectionEmailFunction
+  resource: functionResourse
+states:
+- name: CheckApplication
+  type: SWITCH
+  choices:
+  - path: "$.applicant.age"
+    value: '18'
+    operator: GreaterThanEquals
+    transition:
+      nextState: StartApplication
+  - path: "$.applicant.age"
+    value: '18'
+    operator: LessThan
+    transition:
+      nextState: RejectApplication
+  default:
+    nextState: RejectApplication
+- name: StartApplication
+  type: SUBFLOW
+  workflowId: startApplicationWorkflowId
+  end: true
+- name: RejectApplication
+  type: OPERATION
+  actionMode: SEQUENTIAL
+  actions:
+  - functionref:
+      refname: sendRejectionEmailFunction
+      parameters:
+        applicant: "$.applicant"
+  end: true
+```
+</td>
+</tr>
+</table>
 
 #### Worfklow Diagram
 
@@ -394,97 +596,164 @@ Workflow data is assumed to me:
 
 The data output of the workflow contains the information of the exception caught during workflow execution.
 
-#### Workflow JSON
+#### Workflow Definition
+
+<table>
+<tr>
+    <th>JSON</th>
+    <th>YAML</th>
+</tr>
+<tr>
+<td>
 
 ```json
 {  
-   "name": "Provision Orders",
-   "description": "Provision Orders and handle errors thrown",
-   "startsAt": "ProvisionOrder",
-   "functions": [
-      {
-         "name": "provisionOrderFunction",
-         "resource": "functionResourse"
-      }
-   ],
-   "states":[  
-      {  
-        "name":"ProvisionOrder",
-        "type":"OPERATION",
-        "actionMode":"SEQUENTIAL",
-        "actions":[  
-           {  
-              "functionref": {
-                 "refname": "provisionOrderFunction",
-                 "parameters": {
-                   "order": "$.order"
-                 }
-              }
-           }
-        ],
-        "filter": {
-           "resultPath": "$.exception"
+"name": "Provision Orders",
+"description": "Provision Orders and handle errors thrown",
+"startsAt": "ProvisionOrder",
+"functions": [
+  {
+     "name": "provisionOrderFunction",
+     "resource": "functionResourse"
+  }
+],
+"states":[  
+  {  
+    "name":"ProvisionOrder",
+    "type":"OPERATION",
+    "actionMode":"SEQUENTIAL",
+    "actions":[  
+       {  
+          "functionref": {
+             "refname": "provisionOrderFunction",
+             "parameters": {
+               "order": "$.order"
+             }
+          }
+       }
+    ],
+    "filter": {
+       "resultPath": "$.exception"
+    },
+    "onError": [
+       {
+         "condition": {
+            "expressionLanguage": "spel",
+            "body": "$.exception.name is 'MissingOrderIdException'"
+         },
+         "transition": {
+           "nextState": "MissingId"
+         }
+       },
+       {
+         "condition": {
+           "expressionLanguage": "spel",
+           "body": "$.exception.name is 'MissingOrderItemException'"
+         },
+         "transition": {
+           "nextState": "MissingItem"
+         }
+       },
+       {
+        "condition": {
+          "expressionLanguage": "spel",
+          "body": "$.exception.name is 'MissingOrderQuantityException'"
         },
-        "onError": [
-           {
-             "condition": {
-                "expressionLanguage": "spel",
-                "body": "$.exception.name is 'MissingOrderIdException'"
-             },
-             "transition": {
-               "nextState": "MissingId"
-             }
-           },
-           {
-             "condition": {
-               "expressionLanguage": "spel",
-               "body": "$.exception.name is 'MissingOrderItemException'"
-             },
-             "transition": {
-               "nextState": "MissingItem"
-             }
-           },
-           {
-            "condition": {
-              "expressionLanguage": "spel",
-              "body": "$.exception.name is 'MissingOrderQuantityException'"
-            },
-            "transition": {
-              "nextState": "MissingQuantity"
-            }
-           }
-        ],
         "transition": {
-           "nextState":"ApplyOrder"
+          "nextState": "MissingQuantity"
         }
-    },
-    {
-       "name": "MissingId",
-       "type": "SUBFLOW",
-       "workflowId": "handleMissingIdExceptionWorkflow",
-       "end": true
-    },
-    {
-       "name": "MissingItem",
-       "type": "SUBFLOW",
-       "workflowId": "handleMissingItemExceptionWorkflow",
-       "end": true
-    },
-    {
-       "name": "MissingQuantity",
-       "type": "SUBFLOW",
-       "workflowId": "handleMissingQuantityExceptionWorkflow",
-       "end": true
-    },
-    {
-       "name": "ApplyOrder",
-       "type": "SUBFLOW",
-       "workflowId": "applyOrderWorkflowId",
-       "end": true
+       }
+    ],
+    "transition": {
+       "nextState":"ApplyOrder"
     }
-   ]
+},
+{
+   "name": "MissingId",
+   "type": "SUBFLOW",
+   "workflowId": "handleMissingIdExceptionWorkflow",
+   "end": true
+},
+{
+   "name": "MissingItem",
+   "type": "SUBFLOW",
+   "workflowId": "handleMissingItemExceptionWorkflow",
+   "end": true
+},
+{
+   "name": "MissingQuantity",
+   "type": "SUBFLOW",
+   "workflowId": "handleMissingQuantityExceptionWorkflow",
+   "end": true
+},
+{
+   "name": "ApplyOrder",
+   "type": "SUBFLOW",
+   "workflowId": "applyOrderWorkflowId",
+   "end": true
+}
+]
 }
 ```
+</td>
+<td>
+
+```yaml
+name: Provision Orders
+description: Provision Orders and handle errors thrown
+startsAt: ProvisionOrder
+functions:
+- name: provisionOrderFunction
+  resource: functionResourse
+states:
+- name: ProvisionOrder
+  type: OPERATION
+  actionMode: SEQUENTIAL
+  actions:
+  - functionref:
+      refname: provisionOrderFunction
+      parameters:
+        order: "$.order"
+  filter:
+    resultPath: "$.exception"
+  onError:
+  - condition:
+      expressionLanguage: spel
+      body: "$.exception.name is 'MissingOrderIdException'"
+    transition:
+      nextState: MissingId
+  - condition:
+      expressionLanguage: spel
+      body: "$.exception.name is 'MissingOrderItemException'"
+    transition:
+      nextState: MissingItem
+  - condition:
+      expressionLanguage: spel
+      body: "$.exception.name is 'MissingOrderQuantityException'"
+    transition:
+      nextState: MissingQuantity
+  transition:
+    nextState: ApplyOrder
+- name: MissingId
+  type: SUBFLOW
+  workflowId: handleMissingIdExceptionWorkflow
+  end: true
+- name: MissingItem
+  type: SUBFLOW
+  workflowId: handleMissingItemExceptionWorkflow
+  end: true
+- name: MissingQuantity
+  type: SUBFLOW
+  workflowId: handleMissingQuantityExceptionWorkflow
+  end: true
+- name: ApplyOrder
+  type: SUBFLOW
+  workflowId: applyOrderWorkflowId
+  end: true
+```
+</td>
+</tr>
+</table>
 
 #### Worfklow Diagram
 
@@ -507,157 +776,257 @@ finishes execution.
 In the case job submission raises a runtime error, we transition to a SubFlow state which handles the job submission issue.
 
 
-#### Workflow JSON
+#### Workflow Definition
+
+<table>
+<tr>
+    <th>JSON</th>
+    <th>YAML</th>
+</tr>
+<tr>
+<td>
 
 ```json
-{  
-   "name": "Job Monitoring",
-   "description": "Monitor finished execution of a submitted job",
-   "startsAt": "SubmitJob",
-   "functions": [
-     {
-       "name": "submitJob",
-       "resource": "submitJobResource"
-     },
-     {
-        "name": "checkJobStatus",
-        "resource": "checkJobStatusResource"
-     },
-     {
-        "name": "reportJobSuceeded",
-        "resource": "reportJobSuceededResource"
-     },
-     {
-        "name": "reportJobFailed",
-        "resource": "reportJobFailedResource"
-     }
-   ],
-   "states":[  
-      {  
-        "name":"SubmitJob",
-        "type":"OPERATION",
-        "actionMode":"SEQUENTIAL",
-        "actions":[  
-           {  
-              "functionref": {
-                 "refname": "submitJob",
-                 "parameters": {
-                   "name": "$.job.name"
-                 }
-              }
-           }
-        ],
-        "filter": {
-           "resultPath": "$.jobuid"
-        },
-        "onError": [
-           {
-             "condition": {
-                "expressionLanguage": "spel",
-                "body": "$.exception != null"
-             },
-             "transition": {
-               "nextState": "SubmitError"
-             }
-           }
-        ],
-        "transition": {
-           "nextState":"WaitForCompletion"
-        }
-    },
-    {
-       "name": "SubmitError",
-       "type": "SUBFLOW",
-       "workflowId": "handleJobSubmissionErrorWorkflow",
-       "end": true
-    },
-    {
-       "name": "WaitForCompletion",
-       "type": "DELAY",
-       "timeDelay": "PT5S",
-       "transition": {
-          "nextState":"GetJobStatus"
-       }
-    },
-    {  
-        "name":"GetJobStatus",
-        "type":"OPERATION",
-        "actionMode":"SEQUENTIAL",
-        "actions":[  
-           {  
-              "functionref": {
-                 "refname": "checkJobStatus",
-                 "parameters": {
-                   "name": "$.jobuid"
-                 }
-              }
-           }
-        ],
-        "filter": {
-           "resultPath": "$.jobstatus"
-        },
-        "transition": {
-           "nextState":"DetermineCompletion"
-        }
-    },
-    {  
-     "name":"DetermineCompletion",
-     "type":"SWITCH",
-     "choices": [
-         {
-           "path": "$.jobstatus",
-           "value": "SUCCEEDED",
-           "operator": "Equals",
-           "transition": {
-             "nextState": "JobSucceeded"
-           }
-         },
-         {
-           "path": "$.jobstatus",
-           "value": "FAILED",
-           "operator": "Equals",
-           "transition": {
-             "nextState": "JobFailed"
-           }
-         }
-      ],
-      "default": "WaitForCompletion"
-   },
-   {  
-       "name":"JobSucceeded",
-       "type":"OPERATION",
-       "actionMode":"SEQUENTIAL",
-       "actions":[  
-          {  
-             "functionref": {
-                "refname": "reportJobSuceeded",
-                "parameters": {
-                  "name": "$.jobuid"
-                }
+{   
+"name": "Job Monitoring",
+"description": "Monitor finished execution of a submitted job",
+"startsAt": "SubmitJob",
+"functions": [
+ {
+   "name": "submitJob",
+   "resource": "submitJobResource"
+ },
+ {
+    "name": "checkJobStatus",
+    "resource": "checkJobStatusResource"
+ },
+ {
+    "name": "reportJobSuceeded",
+    "resource": "reportJobSuceededResource"
+ },
+ {
+    "name": "reportJobFailed",
+    "resource": "reportJobFailedResource"
+ }
+],
+"states":[  
+  {  
+    "name":"SubmitJob",
+    "type":"OPERATION",
+    "actionMode":"SEQUENTIAL",
+    "actions":[  
+       {  
+          "functionref": {
+             "refname": "submitJob",
+             "parameters": {
+               "name": "$.job.name"
              }
           }
-       ],
-       "end": true
-   },
-   {  
-      "name":"JobFailed",
-      "type":"OPERATION",
-      "actionMode":"SEQUENTIAL",
-      "actions":[  
-         {  
-            "functionref": {
-               "name": "reportJobFailed",
-               "parameters": {
-                 "name": "$.jobuid"
-               }
+       }
+    ],
+    "filter": {
+       "resultPath": "$.jobuid"
+    },
+    "onError": [
+       {
+         "condition": {
+            "expressionLanguage": "spel",
+            "body": "$.exception != null"
+         },
+         "transition": {
+           "nextState": "SubmitError"
+         }
+       }
+    ],
+    "transition": {
+       "nextState":"WaitForCompletion"
+    }
+},
+{
+   "name": "SubmitError",
+   "type": "SUBFLOW",
+   "workflowId": "handleJobSubmissionErrorWorkflow",
+   "end": true
+},
+{
+   "name": "WaitForCompletion",
+   "type": "DELAY",
+   "timeDelay": "PT5S",
+   "transition": {
+      "nextState":"GetJobStatus"
+   }
+},
+{  
+    "name":"GetJobStatus",
+    "type":"OPERATION",
+    "actionMode":"SEQUENTIAL",
+    "actions":[  
+       {  
+          "functionref": {
+             "refname": "checkJobStatus",
+             "parameters": {
+               "name": "$.jobuid"
+             }
+          }
+       }
+    ],
+    "filter": {
+       "resultPath": "$.jobstatus"
+    },
+    "transition": {
+       "nextState":"DetermineCompletion"
+    }
+},
+{  
+ "name":"DetermineCompletion",
+ "type":"SWITCH",
+ "choices": [
+     {
+       "path": "$.jobstatus",
+       "value": "SUCCEEDED",
+       "operator": "Equals",
+       "transition": {
+         "nextState": "JobSucceeded"
+       }
+     },
+     {
+       "path": "$.jobstatus",
+       "value": "FAILED",
+       "operator": "Equals",
+       "transition": {
+         "nextState": "JobFailed"
+       }
+     }
+  ],
+  "default": "WaitForCompletion"
+},
+{  
+   "name":"JobSucceeded",
+   "type":"OPERATION",
+   "actionMode":"SEQUENTIAL",
+   "actions":[  
+      {  
+         "functionref": {
+            "refname": "reportJobSuceeded",
+            "parameters": {
+              "name": "$.jobuid"
             }
          }
-      ],
-      "end": true
-  }
-  ]
+      }
+   ],
+   "end": true
+},
+{  
+  "name":"JobFailed",
+  "type":"OPERATION",
+  "actionMode":"SEQUENTIAL",
+  "actions":[  
+     {  
+        "functionref": {
+           "name": "reportJobFailed",
+           "parameters": {
+             "name": "$.jobuid"
+           }
+        }
+     }
+  ],
+  "end": true
+}
+]
 }
 ```
+</td>
+<td>
+
+```yaml
+name: Job Monitoring
+description: Monitor finished execution of a submitted job
+startsAt: SubmitJob
+functions:
+- name: submitJob
+  resource: submitJobResource
+- name: checkJobStatus
+  resource: checkJobStatusResource
+- name: reportJobSuceeded
+  resource: reportJobSuceededResource
+- name: reportJobFailed
+  resource: reportJobFailedResource
+states:
+- name: SubmitJob
+  type: OPERATION
+  actionMode: SEQUENTIAL
+  actions:
+  - functionref:
+      refname: submitJob
+      parameters:
+        name: "$.job.name"
+  filter:
+    resultPath: "$.jobuid"
+  onError:
+  - condition:
+      expressionLanguage: spel
+      body: "$.exception != null"
+    transition:
+      nextState: SubmitError
+  transition:
+    nextState: WaitForCompletion
+- name: SubmitError
+  type: SUBFLOW
+  workflowId: handleJobSubmissionErrorWorkflow
+  end: true
+- name: WaitForCompletion
+  type: DELAY
+  timeDelay: PT5S
+  transition:
+    nextState: GetJobStatus
+- name: GetJobStatus
+  type: OPERATION
+  actionMode: SEQUENTIAL
+  actions:
+  - functionref:
+      refname: checkJobStatus
+      parameters:
+        name: "$.jobuid"
+  filter:
+    resultPath: "$.jobstatus"
+  transition:
+    nextState: DetermineCompletion
+- name: DetermineCompletion
+  type: SWITCH
+  choices:
+  - path: "$.jobstatus"
+    value: SUCCEEDED
+    operator: Equals
+    transition:
+      nextState: JobSucceeded
+  - path: "$.jobstatus"
+    value: FAILED
+    operator: Equals
+    transition:
+      nextState: JobFailed
+  default: WaitForCompletion
+- name: JobSucceeded
+  type: OPERATION
+  actionMode: SEQUENTIAL
+  actions:
+  - functionref:
+      refname: reportJobSuceeded
+      parameters:
+        name: "$.jobuid"
+  end: true
+- name: JobFailed
+  type: OPERATION
+  actionMode: SEQUENTIAL
+  actions:
+  - functionref:
+      name: reportJobFailed
+      parameters:
+        name: "$.jobuid"
+  end: true
+```
+</td>
+</tr>
+</table>
 
 #### Worfklow Diagram
 

--- a/workflow/spec/spec-examples.md
+++ b/workflow/spec/spec-examples.md
@@ -815,28 +815,28 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
     "type":"OPERATION",
     "actionMode":"SEQUENTIAL",
     "actions":[  
-       {  
-          "functionref": {
-             "refname": "submitJob",
-             "parameters": {
-               "name": "$.job.name"
-             }
+    {  
+       "functionref": {
+          "refname": "submitJob",
+          "parameters": {
+            "name": "$.job.name"
           }
        }
+    }
     ],
     "filter": {
        "resultPath": "$.jobuid"
     },
     "onError": [
-       {
-         "condition": {
-            "expressionLanguage": "spel",
-            "body": "$.exception != null"
-         },
-         "transition": {
-           "nextState": "SubmitError"
-         }
-       }
+    {
+     "condition": {
+         "expressionLanguage": "spel",
+         "body": "$.exception != null"
+      },
+      "transition": {
+        "nextState": "SubmitError"
+      }
+    }
     ],
     "transition": {
        "nextState":"WaitForCompletion"
@@ -861,14 +861,14 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
     "type":"OPERATION",
     "actionMode":"SEQUENTIAL",
     "actions":[  
-       {  
-          "functionref": {
-             "refname": "checkJobStatus",
-             "parameters": {
-               "name": "$.jobuid"
-             }
+    {  
+      "functionref": {
+          "refname": "checkJobStatus",
+          "parameters": {
+            "name": "$.jobuid"
           }
        }
+    }
     ],
     "filter": {
        "resultPath": "$.jobstatus"
@@ -881,22 +881,22 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
  "name":"DetermineCompletion",
  "type":"SWITCH",
  "choices": [
-     {
-       "path": "$.jobstatus",
-       "value": "SUCCEEDED",
-       "operator": "Equals",
-       "transition": {
-         "nextState": "JobSucceeded"
-       }
-     },
-     {
-       "path": "$.jobstatus",
-       "value": "FAILED",
-       "operator": "Equals",
-       "transition": {
-         "nextState": "JobFailed"
-       }
+   {
+     "path": "$.jobstatus",
+     "value": "SUCCEEDED",
+     "operator": "Equals",
+     "transition": {
+       "nextState": "JobSucceeded"
      }
+   },
+   {
+     "path": "$.jobstatus",
+     "value": "FAILED",
+     "operator": "Equals",
+     "transition": {
+       "nextState": "JobFailed"
+     }
+   }
   ],
   "default": "WaitForCompletion"
 },
@@ -905,14 +905,14 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
    "type":"OPERATION",
    "actionMode":"SEQUENTIAL",
    "actions":[  
-      {  
-         "functionref": {
-            "refname": "reportJobSuceeded",
-            "parameters": {
-              "name": "$.jobuid"
-            }
+   {  
+      "functionref": {
+         "refname": "reportJobSuceeded",
+         "parameters": {
+           "name": "$.jobuid"
          }
       }
+   }
    ],
    "end": true
 },
@@ -921,14 +921,14 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
   "type":"OPERATION",
   "actionMode":"SEQUENTIAL",
   "actions":[  
-     {  
-        "functionref": {
-           "name": "reportJobFailed",
-           "parameters": {
-             "name": "$.jobuid"
-           }
+  {  
+     "functionref": {
+        "name": "reportJobFailed",
+        "parameters": {
+          "name": "$.jobuid"
         }
      }
+  }
   ],
   "end": true
 }
@@ -936,7 +936,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
 }
 ```
 </td>
-<td>
+<td valign="bottom">
 
 ```yaml
 name: Job Monitoring

--- a/workflow/spec/spec-examples.md
+++ b/workflow/spec/spec-examples.md
@@ -39,7 +39,7 @@ value of the "result" property. Since it is an end state, it's data output becom
     <th>YAML</th>
 </tr>
 <tr>
-<td>
+<td valign="top">
 
 ```json
 {  
@@ -72,7 +72,7 @@ value of the "result" property. Since it is an end state, it's data output becom
 }
 ```
 </td>
-<td>
+<td valign="top">
 
 ```yaml
 name: Hello World Workflow
@@ -143,7 +143,7 @@ output, which then becomes the data output of the workflow itself (as it is the 
     <th>YAML</th>
 </tr>
 <tr>
-<td>
+<td valign="top">
 
 ```json
 {  
@@ -181,7 +181,7 @@ output, which then becomes the data output of the workflow itself (as it is the 
 }
 ```
 </td>
-<td>
+<td valign="top">
 
 ```yaml
 name: Greeting Workflow
@@ -242,7 +242,7 @@ result of the workflow execution.
     <th>YAML</th>
 </tr>
 <tr>
-<td>
+<td valign="top">
 
 ```json
 {  
@@ -290,7 +290,7 @@ result of the workflow execution.
 }
 ```
 </td>
-<td>
+<td valign="top">
 
 ```yaml
 name: Solve Math Problems Workflow
@@ -347,7 +347,7 @@ of the branches are done.
     <th>YAML</th>
 </tr>
 <tr>
-<td>
+<td valign="top">
 
 ```json
 {  
@@ -392,7 +392,7 @@ of the branches are done.
 }
 ```
 </td>
-<td>
+<td valign="top">
 
 ```yaml
 name: Parallel Execution Workflow
@@ -459,7 +459,7 @@ If the applicants age is over 18 we start the application (subflow state). Other
     <th>YAML</th>
 </tr>
 <tr>
-<td>
+<td valign="top">
 
 ```json
 {  
@@ -524,7 +524,7 @@ If the applicants age is over 18 we start the application (subflow state). Other
 } 
 ```
 </td>
-<td>
+<td valign="top">
 
 ```yaml
 name: Applicant Request Decision Workflow
@@ -604,7 +604,7 @@ The data output of the workflow contains the information of the exception caught
     <th>YAML</th>
 </tr>
 <tr>
-<td>
+<td valign="top">
 
 ```json
 {  
@@ -696,7 +696,7 @@ The data output of the workflow contains the information of the exception caught
 }
 ```
 </td>
-<td>
+<td valign="top">
 
 ```yaml
 name: Provision Orders
@@ -784,7 +784,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
     <th>YAML</th>
 </tr>
 <tr>
-<td>
+<td valign="top">
 
 ```json
 {   
@@ -936,7 +936,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
 }
 ```
 </td>
-<td valign="bottom">
+<td valign="top">
 
 ```yaml
 name: Job Monitoring

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1892,7 +1892,7 @@ and the state is defined as:
 ```json
 {
 "functions": [ 
-{
+{ 
 "name": "sendConfirmationFunction",
 "resource": "functionResourse"
 }

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -2106,51 +2106,51 @@ output of the state to transition from includes an user with the title "MANAGER"
 
 ```json
 {  
-   "startsAt": "lowRiskState",
-   "functions": [
-      {
-         "name": "doLowRistOperationFunction",
-         "resource": "functionResourse"
-      },
-      {
-         "name": "doHighRistOperationFunction",
-         "resource": "functionResourse"
+"startsAt": "lowRiskState",
+"functions": [
+  {
+   "name": "doLowRistOperationFunction",
+   "resource": "functionResourse"
+  },
+  {
+   "name": "doHighRistOperationFunction",
+   "resource": "functionResourse"
+  }
+],
+"states":[  
+  {  
+   "name":"lowRiskState",
+   "type":"OPERATION",
+   "actionMode":"Sequential",
+   "actions":[  
+    {  
+     "functionref":{
+        "refname": "doLowRistOperationFunction"
+     }
+    }
+    ],
+    "transition": {
+      "nextState":"highRiskState",
+      "condition": {
+         "expressionLanguage": "spel",
+         "body": "#jsonPath(stateOutputData,'$..user.title') eq 'MANAGER'"
       }
-   ],
-   "states":[  
-      {  
-         "name":"lowRiskState",
-         "type":"OPERATION",
-         "actionMode":"Sequential",
-         "actions":[  
-          {  
-            "functionref":{
-               "refname": "doLowRistOperationFunction"
-            }
-          }
-         ],
-         "transition": {
-            "nextState":"highRiskState",
-            "condition": {
-               "expressionLanguage": "spel",
-               "body": "#jsonPath(stateOutputData,'$..user.title') eq 'MANAGER'"
-            }
-         }
-      },
-      {  
-         "name":"highRiskState",
-         "type":"OPERATION",
-         "end":true,
-         "actionMode":"Sequential",
-         "actions":[  
-            {  
-              "functionref":{
-                "refname": "doHighRistOperationFunction"
-              }
-           }
-         ]
-      }
+    }
+  },
+  {  
+   "name":"highRiskState",
+   "type":"OPERATION",
+   "end":true,
+   "actionMode":"Sequential",
+   "actions":[  
+    {  
+     "functionref":{
+       "refname": "doHighRistOperationFunction"
+     }
+    }
    ]
+  }
+]
 }
 ```
 </td>

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1910,15 +1910,15 @@ and the state is defined as:
     "type":"OPERATION",
     "actionMode":"SEQUENTIAL",
     "actions":[  
-       {  
-          "functionref": {
-             "refname": "sendConfirmationFunction",
-             "parameters": {
-               "orderNumber": "$.completedorder.orderNumber",
-               "email": "$.completedorder.email"
-             }
-          }
-       }
+   {  
+   "functionref": {
+      "refname": "sendConfirmationFunction",
+      "parameters": {
+        "orderNumber": "$.completedorder.orderNumber",
+        "email": "$.completedorder.email"
+      }
+   }
+   }
     ],
     "end": true
     }

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1560,7 +1560,7 @@ as data output to the transition state:
     <th>YAML</th>
 </tr>
 <tr>
-<td>
+<td valign="top">
 
   ```json
   {  
@@ -1580,7 +1580,7 @@ as data output to the transition state:
   }
   ```
 </td>
-<td>
+<td valign="top">
 
   ```yaml
   name: SimpleRelayState
@@ -1624,7 +1624,7 @@ what you need as data output of the state. Let's say we have:
     <th>YAML</th>
 </tr>
 <tr>
-<td>
+<td valign="top">
 
   ```json
   {  
@@ -1661,7 +1661,7 @@ what you need as data output of the state. Let's say we have:
     }
   ```
 </td>
-<td>
+<td valign="top">
 
   ```yaml
   name: SimpleRelayState
@@ -1887,7 +1887,7 @@ and the state is defined as:
     <th>YAML</th>
 </tr>
 <tr>
-<td>
+<td valign="top">
 
 ```json
 {
@@ -1929,7 +1929,7 @@ and the state is defined as:
 }
 ```
 </td>
-<td>
+<td valign="top">
 
   ```yaml
 functions:
@@ -2102,7 +2102,7 @@ output of the state to transition from includes an user with the title "MANAGER"
     <th>YAML</th>
 </tr>
 <tr>
-<td>
+<td valign="top">
 
 ```json
 {  
@@ -2154,7 +2154,7 @@ output of the state to transition from includes an user with the title "MANAGER"
 }
 ```
 </td>
-<td>
+<td valign="top">
 
   ```yaml
 startsAt: lowRiskState
@@ -2344,7 +2344,7 @@ Let's take a look at a small example:
     <th>YAML</th>
 </tr>
 <tr>
-<td>
+<td valign="top">
 
 ```json
 {
@@ -2391,7 +2391,7 @@ Let's take a look at a small example:
 }
 ```
 </td>
-<td>
+<td valign="top">
 
 ```yaml
 startsAt: HandleErrors
@@ -2440,7 +2440,7 @@ workflow definition. Let's take a look:
     <th>YAML</th>
 </tr>
 <tr>
-<td>
+<td valign="top">
 
 ```json
 {
@@ -2503,7 +2503,7 @@ workflow definition. Let's take a look:
 }
 ```
 </td>
-<td>
+<td valign="top">
 
 ```yaml
 startsAt: HandleErrors1

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1554,23 +1554,49 @@ You can use the filter property to control the states data output to the transit
 Here is a typical example of how to use the relay state to inject static data into its data input, which then will be passed
 as data output to the transition state:
 
-```json
-{  
-     "name":"SimpleRelayState",
-     "type":"RELAY",
-     "inject": {
-        "person": {
-          "fnam": "John",
-          "lname": "Doe",
-          "address": "1234 SomeStreet",
-          "age": 40
-        }
-     },
-     "transition": {
-        "nextState": "GreetPersonState"
-     }
-}
-```
+<table>
+<tr>
+    <th>JSON</th>
+    <th>YAML</th>
+</tr>
+<tr>
+<td>
+
+  ```json
+  {  
+   "name":"SimpleRelayState",
+   "type":"RELAY",
+   "inject": {
+      "person": {
+        "fnam": "John",
+        "lname": "Doe",
+        "address": "1234 SomeStreet",
+        "age": 40
+      }
+   },
+   "transition": {
+      "nextState": "GreetPersonState"
+   }
+  }
+  ```
+</td>
+<td>
+
+  ```yaml
+  name: SimpleRelayState
+  type: RELAY
+  inject:
+    person:
+      fnam: John
+      lname: Doe
+      address: 1234 SomeStreet
+      age: 40
+  transition:
+    nextState: GreetPersonState
+  ```
+</td>
+</tr>
+</table>
 
 The data output of the "SimpleRelayState" which then is passed as input to the transition state would be:
 
@@ -1638,26 +1664,26 @@ what you need as data output of the state. Let's say we have:
 <td>
 
   ```yaml
-      name: SimpleRelayState
-      type: RELAY
-      inject:
-        people:
-        - fnam: John
-          lname: Doe
-          address: 1234 SomeStreet
-          age: 40
-        - fnam: Marry
-          lname: Allice
-          address: 1234 SomeStreet
-          age: 25
-        - fnam: Kelly
-          lname: Mill
-          address: 1234 SomeStreet
-          age: 30
-      filter:
-        outputPath: "$.people[?(@.age < 40)]"
-      transition:
-        nextState: GreetPersonState
+  name: SimpleRelayState
+  type: RELAY
+  inject:
+    people:
+    - fnam: John
+      lname: Doe
+      address: 1234 SomeStreet
+      age: 40
+    - fnam: Marry
+      lname: Allice
+      address: 1234 SomeStreet
+      age: 25
+    - fnam: Kelly
+      lname: Mill
+      address: 1234 SomeStreet
+      age: 30
+  filter:
+    outputPath: "$.people[?(@.age < 40)]"
+  transition:
+    nextState: GreetPersonState
   ```
 </td>
 </tr>

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1590,14 +1590,13 @@ If the relay state already receives a data input from the previous transition st
 with its data input.
 
 You can also use the filter property to further relay the set-up data input and pass only
-what you need as data output of the state. Let's say we have a workflow definition:
+what you need as data output of the state. Let's say we have the following workflow definition:
 
-
-
-<table>
-<tr>
-<td>
-
+<table><tr>
+    <th>JSON</th>
+    <th>YAML</th>
+  </tr>
+<tr><td>
   <pre>
   {  
        "name":"SimpleRelayState",
@@ -1632,9 +1631,8 @@ what you need as data output of the state. Let's say we have a workflow definiti
        }
   }
   </pre>
-</td>
-<td>
-
+</td><td>
+<tr><td>
   <pre>
     {  
          "name":"SimpleRelayState",
@@ -1669,10 +1667,7 @@ what you need as data output of the state. Let's say we have a workflow definiti
          }
     }
     </pre>
-</td>
-</tr>
-</table>
-
+</td></tr></table>
 
 In which case the states data output would include people whos age is less than 40. You can then easily during testing 
 change your output path to for example:

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1660,9 +1660,6 @@ what you need as data output of the state. Let's say we have:
         nextState: GreetPersonState
   ```
 </td>
-<td>
-  Variables defined with <code>def</code> cannot be changed once defined. This is similar to <code>readonly</code> or <code>const</code> in C# or <code>final</code> in Java. Most variables in Nemerle aren't explicitly typed like this.
-</td>
 </tr>
 </table>
 

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1891,7 +1891,7 @@ and the state is defined as:
 
 ```json
 {
-"functions": [
+"functions": [ 
 {
 "name": "sendConfirmationFunction",
 "resource": "functionResourse"

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1656,6 +1656,31 @@ what you need as data output of the state. Let's say we have the following workf
     </pre>
 </td></tr></table>
 
+
+<table>
+<tr>
+<td>
+
+  ```csharp
+  const int x = 3;
+  const string y = "foo";
+  readonly Object obj = getObject();
+  ```
+</td>
+<td>
+
+  ```nemerle
+  def x : int = 3;
+  def y : string = "foo";
+  def obj : Object = getObject();
+  ```
+</td>
+<td>
+  Variables defined with <code>def</code> cannot be changed once defined. This is similar to <code>readonly</code> or <code>const</code> in C# or <code>final</code> in Java. Most variables in Nemerle aren't explicitly typed like this.
+</td>
+</tr>
+</table>
+
 In which case the states data output would include people whos age is less than 40. You can then easily during testing 
 change your output path to for example:
 

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1880,45 +1880,83 @@ In this example the data input to our ForEach state is an array of orders:
 
 and the state is defined as:
 
+
+<table>
+<tr>
+    <th>JSON</th>
+    <th>YAML</th>
+</tr>
+<tr>
+<td>
+
 ```json
 {
 "functions": [
-  {
-    "name": "sendConfirmationFunction",
-    "resource": "functionResourse"
-  }
+{
+"name": "sendConfirmationFunction",
+"resource": "functionResourse"
+}
 ],
 "states": [
-  {   
-     "name":"SendConfirmationForEachCompletedhOrder",
-     "type":"FOREACH",
-     "inputCollection": "$.orders[?(@.completed == true)]",
-     "inputParameter": "$.completedorder",
-     "startsAt": "SendConfirmation",
-     "states": [
-        {  
-            "name":"SendConfirmation",
-            "type":"OPERATION",
-            "actionMode":"SEQUENTIAL",
-            "actions":[  
-               {  
-                  "functionref": {
-                     "refname": "sendConfirmationFunction",
-                     "parameters": {
-                       "orderNumber": "$.completedorder.orderNumber",
-                       "email": "$.completedorder.email"
-                     }
-                  }
-               }
-            ],
-            "end": true
-        }
-     ],
-     "end": true
-  } 
+{   
+ "name":"SendConfirmationForEachCompletedhOrder",
+ "type":"FOREACH",
+ "inputCollection": "$.orders[?(@.completed == true)]",
+ "inputParameter": "$.completedorder",
+ "startsAt": "SendConfirmation",
+ "states": [
+    {  
+    "name":"SendConfirmation",
+    "type":"OPERATION",
+    "actionMode":"SEQUENTIAL",
+    "actions":[  
+       {  
+          "functionref": {
+             "refname": "sendConfirmationFunction",
+             "parameters": {
+               "orderNumber": "$.completedorder.orderNumber",
+               "email": "$.completedorder.email"
+             }
+          }
+       }
+    ],
+    "end": true
+    }
+ ],
+ "end": true
+} 
 ]
 }
 ```
+</td>
+<td>
+
+  ```yaml
+functions:
+- name: sendConfirmationFunction
+  resource: functionResourse
+states:
+- name: SendConfirmationForEachCompletedhOrder
+  type: FOREACH
+  inputCollection: "$.orders[?(@.completed == true)]"
+  inputParameter: "$.completedorder"
+  startsAt: SendConfirmation
+  states:
+  - name: SendConfirmation
+    type: OPERATION
+    actionMode: SEQUENTIAL
+    actions:
+    - functionref:
+        refname: sendConfirmationFunction
+        parameters:
+          orderNumber: "$.completedorder.orderNumber"
+          email: "$.completedorder.email"
+    end: true
+  end: true
+  ```
+</td>
+</tr>
+</table>
 
 This ForEach state will first look at its inputCollection path to determine which array in the states data input
 to iterate over.
@@ -1929,14 +1967,6 @@ set to true.
 For each of the completed order the state will then execute the defined set of states in parallel.
 
 For this example, the data inputs of staring states for the two itererations would be: 
-
-<table>
-<tr>
-    <th>JSON</th>
-    <th>YAML</th>
-</tr>
-<tr>
-<td>
 
 ```json
 {
@@ -1963,31 +1993,7 @@ For this example, the data inputs of staring states for the two itererations wou
         "email": "firstBuyer@buyer.com"
     }
 }
-```
-</td>
-<td>
-
-  ```yaml
-  name: Send order confirmation email
-  description: Send email for each confirmed order
-  startsAt: sendConfirmationEmail
-  functions:
-  - name: sendConfirmationEmailFunction
-    resource: functionResourse
-  states:
-  - name: sendConfirmationEmail
-    type: OPERATION
-    actionMode: SEQUENTIAL
-    actions:
-    - functionref:
-        refname: sendConfirmationEmailFunction
-    end: true
-    loop:
-      inputCollection: "$.orders[?(@.completed == true)]"
-  ```
-</td>
-</tr>
-</table>
+```    
 
 and:
 

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -27,6 +27,7 @@ The goal of the Serverless Workflow sub-group is to:
 - Facilitate Serverless Workflow portability
 - Be completely vendor neutral
 - Support both stateless and stateful Serverless Workflow implementations
+- Supply a light-weight, human-readable, and embeddable format for describing serverless workflows
 
 The Serverless Workflow specification defined in this document incorporates all of these goals.
 
@@ -37,6 +38,7 @@ This document is a working draft.
 ## Table of Contents
 
 - [Introduction](#Introduction)
+- [Workflow Format](#Workflow-Format)
 - [Functional Scope](#Functional-Scope)
 - [Specification Details](#Specification-Details)
     - [Workflow Model](#Workflow-Model)
@@ -59,6 +61,14 @@ simplifies orchestration of the app logic.
 control flow and how/which functions are to be invoked on arrival of events.
 * **Define and manage application data flow**: allows the users to define how data is passed and filtered from incoming events to states, 
 from states to functions, from one function to another function, and from one state to another state.
+
+### Workflow Format
+
+Serverless workflows are defined with [JSON](https://www.json.org/json-en.html) or [YAML](https://yaml.org/) formats.
+Structure of serverless workflows is described via [JSON Schema](https://json-schema.org/).
+
+Serverless Workflow definitions are considered specification-compliant if they conform to the [workflow schema](schema/serverless-workflow-schema-01.json).
+Note that this schema reflects the current status of the specification as is updated alongside this document. 
 
 ### Functional Scope
 
@@ -85,9 +95,6 @@ incoming events can trigger function calls during flow execution.
 Following sections provide detailed descriptions of the Serverless Workflow Model. For each part of the model we provide:
 - Parameter description in table format
 - [JSON Schema](https://json-schema.org/) definition 
-
-You can find the entire Serverless Workflow JSON Schema [here](schema/serverless-workflow-schema-01.json).
-Note that this schema reflects the current status of the specification as is updated alongside this document. 
 
 ### Workflow Model
 
@@ -1583,42 +1590,89 @@ If the relay state already receives a data input from the previous transition st
 with its data input.
 
 You can also use the filter property to further relay the set-up data input and pass only
-what you need as data output of the state. Let's say we have:
+what you need as data output of the state. Let's say we have a workflow definition:
 
-```json
-{  
-     "name":"SimpleRelayState",
-     "type":"RELAY",
-     "inject": {
-        "people": [
-          {
-             "fnam": "John",
-             "lname": "Doe",
-             "address": "1234 SomeStreet",
-             "age": 40
-          },
-          {
-             "fnam": "Marry",
-             "lname": "Allice",
-             "address": "1234 SomeStreet",
-             "age": 25
-          },
-          {
-             "fnam": "Kelly",
-             "lname": "Mill",
-             "address": "1234 SomeStreet",
-             "age": 30
-          }
-        ]
-     },
-     "filter": {
-        "outputPath": "$.people[?(@.age < 40)]"
-     },
-     "transition": {
-        "nextState": "GreetPersonState"
-     }
-}
-```
+
+
+<table>
+<tr>
+<td>
+
+  ```json
+  {  
+       "name":"SimpleRelayState",
+       "type":"RELAY",
+       "inject": {
+          "people": [
+            {
+               "fnam": "John",
+               "lname": "Doe",
+               "address": "1234 SomeStreet",
+               "age": 40
+            },
+            {
+               "fnam": "Marry",
+               "lname": "Allice",
+               "address": "1234 SomeStreet",
+               "age": 25
+            },
+            {
+               "fnam": "Kelly",
+               "lname": "Mill",
+               "address": "1234 SomeStreet",
+               "age": 30
+            }
+          ]
+       },
+       "filter": {
+          "outputPath": "$.people[?(@.age < 40)]"
+       },
+       "transition": {
+          "nextState": "GreetPersonState"
+       }
+  }
+  ```
+</td>
+<td>
+
+  ```json
+    {  
+         "name":"SimpleRelayState",
+         "type":"RELAY",
+         "inject": {
+            "people": [
+              {
+                 "fnam": "John",
+                 "lname": "Doe",
+                 "address": "1234 SomeStreet",
+                 "age": 40
+              },
+              {
+                 "fnam": "Marry",
+                 "lname": "Allice",
+                 "address": "1234 SomeStreet",
+                 "age": 25
+              },
+              {
+                 "fnam": "Kelly",
+                 "lname": "Mill",
+                 "address": "1234 SomeStreet",
+                 "age": 30
+              }
+            ]
+         },
+         "filter": {
+            "outputPath": "$.people[?(@.age < 40)]"
+         },
+         "transition": {
+            "nextState": "GreetPersonState"
+         }
+    }
+    ```
+</td>
+</tr>
+</table>
+
 
 In which case the states data output would include people whos age is less than 40. You can then easily during testing 
 change your output path to for example:

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1597,8 +1597,7 @@ what you need as data output of the state. Let's say we have the following workf
     <th>YAML</th>
   </tr>
 <tr><td>
-
-  ```json
+  <pre>
   {  
        "name":"SimpleRelayState",
        "type":"RELAY",
@@ -1631,10 +1630,9 @@ what you need as data output of the state. Let's say we have the following workf
           "nextState": "GreetPersonState"
        }
   }
-  ```
+  </pre>
 </td><td>
-
-  ```yaml
+  <pre>
     {  
          "name":"SimpleRelayState",
          "type":"RELAY",
@@ -1667,7 +1665,7 @@ what you need as data output of the state. Let's say we have the following workf
             "nextState": "GreetPersonState"
          }
     }
-    ```
+    </pre>
 </td></tr></table>
 
 In which case the states data output would include people whos age is less than 40. You can then easily during testing 

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1602,36 +1602,36 @@ what you need as data output of the state. Let's say we have:
 
   ```json
   {  
-         "name":"SimpleRelayState",
-         "type":"RELAY",
-         "inject": {
-            "people": [
-              {
-                 "fnam": "John",
-                 "lname": "Doe",
-                 "address": "1234 SomeStreet",
-                 "age": 40
-              },
-              {
-                 "fnam": "Marry",
-                 "lname": "Allice",
-                 "address": "1234 SomeStreet",
-                 "age": 25
-              },
-              {
-                 "fnam": "Kelly",
-                 "lname": "Mill",
-                 "address": "1234 SomeStreet",
-                 "age": 30
-              }
-            ]
-         },
-         "filter": {
-            "outputPath": "$.people[?(@.age < 40)]"
-         },
-         "transition": {
-            "nextState": "GreetPersonState"
-         }
+     "name":"SimpleRelayState",
+     "type":"RELAY",
+     "inject": {
+        "people": [
+          {
+             "fnam": "John",
+             "lname": "Doe",
+             "address": "1234 SomeStreet",
+             "age": 40
+          },
+          {
+             "fnam": "Marry",
+             "lname": "Allice",
+             "address": "1234 SomeStreet",
+             "age": 25
+          },
+          {
+             "fnam": "Kelly",
+             "lname": "Mill",
+             "address": "1234 SomeStreet",
+             "age": 30
+          }
+        ]
+     },
+     "filter": {
+        "outputPath": "$.people[?(@.age < 40)]"
+     },
+     "transition": {
+        "nextState": "GreetPersonState"
+     }
     }
   ```
 </td>

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1598,7 +1598,7 @@ what you need as data output of the state. Let's say we have a workflow definiti
 <tr>
 <td>
 
-  ```json
+  <pre>
   {  
        "name":"SimpleRelayState",
        "type":"RELAY",
@@ -1631,11 +1631,11 @@ what you need as data output of the state. Let's say we have a workflow definiti
           "nextState": "GreetPersonState"
        }
   }
-  ```
+  </pre>
 </td>
 <td>
 
-  ```json
+  <pre>
     {  
          "name":"SimpleRelayState",
          "type":"RELAY",
@@ -1668,7 +1668,7 @@ what you need as data output of the state. Let's say we have a workflow definiti
             "nextState": "GreetPersonState"
          }
     }
-    ```
+    </pre>
 </td>
 </tr>
 </table>

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1632,7 +1632,6 @@ what you need as data output of the state. Let's say we have the following workf
   }
   </pre>
 </td><td>
-<tr><td>
   <pre>
     {  
          "name":"SimpleRelayState",

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1597,7 +1597,8 @@ what you need as data output of the state. Let's say we have the following workf
     <th>YAML</th>
   </tr>
 <tr><td>
-  <pre>
+
+  ```json
   {  
        "name":"SimpleRelayState",
        "type":"RELAY",
@@ -1630,9 +1631,10 @@ what you need as data output of the state. Let's say we have the following workf
           "nextState": "GreetPersonState"
        }
   }
-  </pre>
+  ```
 </td><td>
-  <pre>
+
+  ```yaml
     {  
          "name":"SimpleRelayState",
          "type":"RELAY",
@@ -1665,7 +1667,7 @@ what you need as data output of the state. Let's say we have the following workf
             "nextState": "GreetPersonState"
          }
     }
-    </pre>
+    ```
 </td></tr></table>
 
 In which case the states data output would include people whos age is less than 40. You can then easily during testing 

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1633,38 +1633,26 @@ what you need as data output of the state. Let's say we have the following workf
   </pre>
 </td><td>
   <pre>
-    {  
-         "name":"SimpleRelayState",
-         "type":"RELAY",
-         "inject": {
-            "people": [
-              {
-                 "fnam": "John",
-                 "lname": "Doe",
-                 "address": "1234 SomeStreet",
-                 "age": 40
-              },
-              {
-                 "fnam": "Marry",
-                 "lname": "Allice",
-                 "address": "1234 SomeStreet",
-                 "age": 25
-              },
-              {
-                 "fnam": "Kelly",
-                 "lname": "Mill",
-                 "address": "1234 SomeStreet",
-                 "age": 30
-              }
-            ]
-         },
-         "filter": {
-            "outputPath": "$.people[?(@.age < 40)]"
-         },
-         "transition": {
-            "nextState": "GreetPersonState"
-         }
-    }
+    name: SimpleRelayState
+    type: RELAY
+    inject:
+      people:
+      - fnam: John
+        lname: Doe
+        address: 1234 SomeStreet
+        age: 40
+      - fnam: Marry
+        lname: Allice
+        address: 1234 SomeStreet
+        age: 25
+      - fnam: Kelly
+        lname: Mill
+        address: 1234 SomeStreet
+        age: 30
+    filter:
+      outputPath: "$.people[?(@.age < 40)]"
+    transition:
+      nextState: GreetPersonState
     </pre>
 </td></tr></table>
 

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1590,89 +1590,74 @@ If the relay state already receives a data input from the previous transition st
 with its data input.
 
 You can also use the filter property to further relay the set-up data input and pass only
-what you need as data output of the state. Let's say we have the following workflow definition:
-
-<table><tr>
-    <th>JSON</th>
-    <th>YAML</th>
-  </tr>
-<tr><td>
-  <pre>
-  {  
-       "name":"SimpleRelayState",
-       "type":"RELAY",
-       "inject": {
-          "people": [
-            {
-               "fnam": "John",
-               "lname": "Doe",
-               "address": "1234 SomeStreet",
-               "age": 40
-            },
-            {
-               "fnam": "Marry",
-               "lname": "Allice",
-               "address": "1234 SomeStreet",
-               "age": 25
-            },
-            {
-               "fnam": "Kelly",
-               "lname": "Mill",
-               "address": "1234 SomeStreet",
-               "age": 30
-            }
-          ]
-       },
-       "filter": {
-          "outputPath": "$.people[?(@.age < 40)]"
-       },
-       "transition": {
-          "nextState": "GreetPersonState"
-       }
-  }
-  </pre>
-</td><td>
-  <pre>
-    name: SimpleRelayState
-    type: RELAY
-    inject:
-      people:
-      - fnam: John
-        lname: Doe
-        address: 1234 SomeStreet
-        age: 40
-      - fnam: Marry
-        lname: Allice
-        address: 1234 SomeStreet
-        age: 25
-      - fnam: Kelly
-        lname: Mill
-        address: 1234 SomeStreet
-        age: 30
-    filter:
-      outputPath: "$.people[?(@.age < 40)]"
-    transition:
-      nextState: GreetPersonState
-    </pre>
-</td></tr></table>
-
+what you need as data output of the state. Let's say we have:
 
 <table>
 <tr>
+    <th>JSON</th>
+    <th>YAML</th>
+</tr>
+<tr>
 <td>
 
-  ```csharp
-  const int x = 3;
-  const string y = "foo";
-  readonly Object obj = getObject();
+  ```json
+  {  
+         "name":"SimpleRelayState",
+         "type":"RELAY",
+         "inject": {
+            "people": [
+              {
+                 "fnam": "John",
+                 "lname": "Doe",
+                 "address": "1234 SomeStreet",
+                 "age": 40
+              },
+              {
+                 "fnam": "Marry",
+                 "lname": "Allice",
+                 "address": "1234 SomeStreet",
+                 "age": 25
+              },
+              {
+                 "fnam": "Kelly",
+                 "lname": "Mill",
+                 "address": "1234 SomeStreet",
+                 "age": 30
+              }
+            ]
+         },
+         "filter": {
+            "outputPath": "$.people[?(@.age < 40)]"
+         },
+         "transition": {
+            "nextState": "GreetPersonState"
+         }
+    }
   ```
 </td>
 <td>
 
-  ```nemerle
-  def x : int = 3;
-  def y : string = "foo";
-  def obj : Object = getObject();
+  ```yaml
+      name: SimpleRelayState
+      type: RELAY
+      inject:
+        people:
+        - fnam: John
+          lname: Doe
+          address: 1234 SomeStreet
+          age: 40
+        - fnam: Marry
+          lname: Allice
+          address: 1234 SomeStreet
+          age: 25
+        - fnam: Kelly
+          lname: Mill
+          address: 1234 SomeStreet
+          age: 30
+      filter:
+        outputPath: "$.people[?(@.age < 40)]"
+      transition:
+        nextState: GreetPersonState
   ```
 </td>
 <td>


### PR DESCRIPTION
Describes YAML support for workflow definitions.

Updates all examples in spec.md and spec-examples.md to show 
both JSON and YAML workflow definitions side-by-side.

You can visually see what updates look like:
https://github.com/tsurdilo/wg-serverless/blob/yamlsupport/workflow/spec/spec.md
https://github.com/tsurdilo/wg-serverless/blob/yamlsupport/workflow/spec/spec-examples.md