### PR TITLE
Removing execStatus property

### DIFF
--- a/workflow/spec/schema/serverless-workflow-schema-01.json
+++ b/workflow/spec/schema/serverless-workflow-schema-01.json
@@ -31,16 +31,6 @@
       "type": "string",
       "description": "Starts at state name"
     },
-    "execStatus": {
-      "type": "string",
-      "enum": [
-        "Success",
-        "Fail",
-        "Timeout",
-        "Invalid"
-      ],
-      "description": "Workflow execution status"
-    },
     "expressionLanguage": {
       "type": "string",
       "description": "Default expression language to be used throughout the workflow definition"

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -123,7 +123,6 @@ Here we define details of the Serverless Workflow definitions:
 | version | Workflow version | string |no |
 | schemaVersion | Workflow schema version | string |no |
 | startsAt | Workflow starting state | string |yes |
-| execStatus |Workflow execution status | string |no |
 | expressionLanguage |Default expression language to be used throughout the workflow definition | string |no |
 | [triggers](#Trigger-Definition) |Workflow trigger events | array | no |
 | [functions](#Function-Definition) |Workflow functions | array | no |
@@ -167,11 +166,6 @@ Here we define details of the Serverless Workflow definitions:
         "startsAt": {
             "type": "string",
             "description": "State name which is the starting state"
-        },
-        "execStatus": {
-            "type" : "string",
-            "enum": ["Success", "Fail", "Timeout", "Invalid"],
-            "description": "Execution status"
         },
         "expressionLanguage": {
           "type": "string",


### PR DESCRIPTION
Removing execStatus property as:
* we do not describe currently what it does
* we do no explain how it is set during workflow execution
* we added workflow data input / output which can contain this information

I will revisit this soon and propose an alternative way for it then we can discuss, but for now this property is useless