### PR TITLE
Adding spec roadmap document

### DIFF
--- a/workflow/spec/roadmap.md
+++ b/workflow/spec/roadmap.md
@@ -1,0 +1,45 @@
+# Roadmap
+
+The Serverless Workflow Roadmap.
+
+_Note: Items in tables for each milestone do not imply an order of implementation._
+
+_Note: Milestone entries include the most notable updates only. For list of all commits see [link](https://github.com/cncf/wg-serverless/commits/master)_
+
+_Status description:_
+
+| Completed | In Progress | In Planning |
+| --- | --- |  --- | --- |
+|  <center>✔</center> | <center>✏️</center> | <center>🚩</center> |
+
+## Setup (ETA: end of March 2020)
+
+| Status | Description | Comments |
+| --- | --- |  --- |
+|  ✔ | Establish governance, contributing guidelines and initial stakeholder | [governance doc](governance/readme.md)  |
+|  ✔ | Define specification goals | [spec doc](spec.md) |
+|  ✔ | Define specification functional scope | [spec doc](spec.md) |
+|  ✔ | Include set of use-cases for Serverless Workflow | [spec usecases doc](spec-usecases.md) |
+|  ✔ | Include set of examples for Serverless Workflow | [spec examples doc](spec-examples.md) |
+|  ✔ | Define specification JSON Schema | [spec doc](spec.md) |
+|  ✔ | Add SubFlow state | [spec doc](spec.md) |
+|  ✔ | Add Relay state | [spec doc](spec.md) |
+|  ✔ | Add ForEach state | [spec doc](spec.md) |
+|  ✏️ | Add Callback state | [pr](https://github.com/cncf/wg-serverless/pull/174) |
+|  ✔ | Update Event state| [spec doc](spec.md) |
+|  ✔ | Define Workflow data input/output | [spec doc](spec.md) |
+|  ✔ | Update state data filtering | [spec doc](spec.md) |
+|  ✔ | Clearly define workflow info passing | [spec doc](spec.md) |
+|  ✔ | Add Workflow error handling | [spec doc](spec.md) |
+|  ✔ | Add reusable function definitions | [spec doc](spec.md) |
+|  ✔ | Add support for YAML definitions | [spec doc](spec.md) |
+|  ✔ | Update workflow completion (end definition) | [spec doc](spec.md) |
+|  🚩 | Decide on state/task/stage/step naming convention | [issue link](https://github.com/cncf/wg-serverless/issues/127) |
+|  🚩 | Decide to split spec.md into multiple docs (for easier pr management) | |
+|  ✏️ | Finish specification primer document | |
+|  ✏️ | Prepare github branch and docs for v0.1 | |
+
+## v0.1 (Planned to start April 2020)
+
+| Status | Description | Comments |
+| --- | --- |  --- |

--- a/workflow/spec/roadmap.md
+++ b/workflow/spec/roadmap.md
@@ -8,9 +8,9 @@ _Note: Milestone entries include the most notable updates only. For list of all 
 
 _Status description:_
 
-| Completed | In Progress | In Planning |
-| --- | --- |  --- |
-|  <center>✔</center> | <center>✏️</center> | <center>🚩</center> |
+| Completed | In Progress | In Planning | On Hold |
+| --- | --- |  --- | --- |
+|  <center>✔</center> | <center>✏️</center> | <center>🚩</center> | <center>❗️</center>
 
 ## Setup (ETA: end of March 2020)
 
@@ -37,7 +37,7 @@ _Status description:_
 |  🚩 | Decide on state/task/stage/step naming convention | [issue link](https://github.com/cncf/wg-serverless/issues/127) |
 |  🚩 | Decide to split spec.md into multiple docs (for easier pr management) | |
 |  ✏️ | Finish specification primer document | |
-|  ✏️ | Prepare github branch and docs for v0.1 | |
+|  🚩 | Prepare github branch and docs for v0.1 | |
 
 ## v0.1 (Planned to start April 2020)
 

--- a/workflow/spec/roadmap.md
+++ b/workflow/spec/roadmap.md
@@ -9,7 +9,7 @@ _Note: Milestone entries include the most notable updates only. For list of all 
 _Status description:_
 
 | Completed | In Progress | In Planning |
-| --- | --- |  --- | --- |
+| --- | --- |  --- |
 |  <center>✔</center> | <center>✏️</center> | <center>🚩</center> |
 
 ## Setup (ETA: end of March 2020)


### PR DESCRIPTION
We really need a roadmap document so can show what has been done and what we are planning to do.
Please review and give comments if anything needs to be added to the "Setup" milestone.

You can see the parsed markdown here: https://github.com/tsurdilo/wg-serverless/blob/addroadmap2/workflow/spec/roadmap.md