### PR TITLE
Adding Manuel Stein to list of spec owners

### DIFF
--- a/workflow/spec/governance/owners.md
+++ b/workflow/spec/governance/owners.md
@@ -6,3 +6,4 @@ These people are currently responsible for overseeing, reviewing, and approving 
 * [Cathy Hong Zhang](https://github.com/cathyhongzhang)
 * [Tihomir Surdilovic](https://github.com/tsurdilo)
 * [Mauricio Salatino](https://github.com/salaboy)
+* [Manuel Stein](https://github.com/manuelstein)


### PR DESCRIPTION
Manuel is heavily involved with the specification and has shown alot of interest and dedicated his time on it. He has shown deep knowledge of the subject and is driving our meetings and work on the primer document. 

