### PR TITLE
Rename Relay to Inject state

### DIFF
--- a/workflow/spec/examples.md
+++ b/workflow/spec/examples.md
@@ -20,7 +20,7 @@
 
 #### Description
 
-This example uses two relay states. The "Hello" state statically injects the following JSON into its data input:
+This example uses two inject states. The "Hello" state statically injects the following JSON into its data input:
 
 ```json
 {
@@ -55,11 +55,11 @@ value of the "result" property. Since it is an end state, it's data output becom
 "states":[  
   {  
      "name":"Hello",
-     "type":"RELAY",
+     "type":"INJECT",
      "start": {
        "kind": "DEFAULT"
      },
-     "inject": {
+     "data": {
         "result": "Hello"
      },
      "transition": {
@@ -68,8 +68,8 @@ value of the "result" property. Since it is an end state, it's data output becom
   },
   {  
      "name":"World",
-     "type":"RELAY",
-     "inject": {
+     "type":"INJECT",
+     "data": {
         "result": " World!"
      },
      "stateDataFilter": {
@@ -93,16 +93,16 @@ name: Hello World Workflow
 description: Static Hello World
 states:
 - name: Hello
-  type: RELAY
+  type: INJECT
   start:
     kind: DEFAULT
-  inject:
+  data:
     result: Hello
   transition:
     nextState: World
 - name: World
-  type: RELAY
-  inject:
+  type: INJECT
+  data:
     result: " World!"
   stateDataFilter:
     dataOutputPath: "$.result"

--- a/workflow/spec/roadmap.md
+++ b/workflow/spec/roadmap.md
@@ -45,4 +45,5 @@ _Status description:_
 | 🚩 | Start discussions on Serverless Workflow Technology Compatibility Kit (TCK) | |
 | 🚩 | Decide on state/task/stage/step naming convention | [issue link](https://github.com/cncf/wg-serverless/issues/127) |
 | ✏️ | Finish specification primer document | [google doc](https://docs.google.com/document/d/11rD3Azj63G2Si0VpokSpr-1ib3mFRFHSwN6tJb-0LQM/edit#heading=h.paewfy83tetm) |
+| ✏ | Rename Relay to Inject state |  |
 

--- a/workflow/spec/schema/serverless-workflow-schema.json
+++ b/workflow/spec/schema/serverless-workflow-schema.json
@@ -92,8 +92,8 @@
             "$ref": "#/definitions/subflowstate"
           },
           {
-            "title": "Relay State",
-            "$ref": "#/definitions/relaystate"
+            "title": "Inject State",
+            "$ref": "#/definitions/inject"
           },
           {
             "title": "ForEach State",
@@ -348,8 +348,8 @@
                 "$ref": "#/definitions/subflowstate"
               },
               {
-                "title": "Relay State",
-                "$ref": "#/definitions/relaystate"
+                "title": "Inject State",
+                "$ref": "#/definitions/injectstate"
               },
               {
                 "title": "ForEach State",
@@ -1024,9 +1024,9 @@
         }
       ]
     },
-    "relaystate": {
+    "inject": {
       "type": "object",
-      "description": "Set up and relay the state's data input to data output. Does not perform any actions",
+      "description": "Inject statit data into state data. Does not perform any actions",
       "properties": {
         "id": {
           "type": "string",
@@ -1040,7 +1040,7 @@
         "type": {
           "type": "string",
           "enum": [
-            "RELAY"
+            "INJECT"
           ],
           "description": "State type"
         },
@@ -1052,7 +1052,7 @@
           "$ref": "#/definitions/end",
           "description": "State end definition"
         },
-        "inject": {
+        "data": {
           "type": "object",
           "description": "JSON object which can be set as states data input and can be manipulated via filters"
         },
@@ -1186,8 +1186,8 @@
                 "$ref": "#/definitions/subflowstate"
               },
               {
-                "title": "Relay State",
-                "$ref": "#/definitions/relaystate"
+                "title": "Inject State",
+                "$ref": "#/definitions/injectstate"
               },
               {
                 "title": "ForEach State",


### PR DESCRIPTION
Renames Relay state to Inject state so it's name makes more sense.

After getting some info from community, one of the bigger complaints was that noone understood what the name "Relay" means in relay state. It is a state that injects static data into the state data input. So from that changing:

Relay State / inject property 
to
Inject State / data property

to clearly describe that this is a state that "injects" "data".

