### PR TITLE
Updating Switch State

### DIFF
--- a/workflow/spec/examples.md
+++ b/workflow/spec/examples.md
@@ -694,7 +694,7 @@ This example shows off the switch state and the subflow state. The workflow is s
     }
 ```
 
-We use the switch state with two choices to determine if the application should be made based on the applicants age.
+We use the switch state with two conditions to determine if the application should be made based on the applicants age.
 If the applicants age is over 18 we start the application (subflow state). Otherwise the workflow notifies the
  applicant of the rejection.
 
@@ -727,11 +727,11 @@ If the applicants age is over 18 we start the application (subflow state). Other
          "start": {
             "kind": "DEFAULT"
          },
-         "choices": [
+         "conditions": [
             {
               "path": "$.applicant.age",
               "value": "18",
-              "operator": "GreaterThanEquals",
+              "operator": "GreaterThanOrEquals",
               "transition": {
                 "nextState": "StartApplication"
               }
@@ -795,10 +795,10 @@ states:
   type: SWITCH
   start:
     kind: DEFAULT
-  choices:
+  conditions:
   - path: "$.applicant.age"
     value: '18'
-    operator: GreaterThanEquals
+    operator: GreaterThanOrEquals
     transition:
       nextState: StartApplication
   - path: "$.applicant.age"
@@ -1179,7 +1179,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
   {  
     "name":"DetermineCompletion",
     "type":"SWITCH",
-    "choices": [
+    "conditions": [
       {
         "path": "$.jobstatus",
         "value": "SUCCEEDED",
@@ -1309,7 +1309,7 @@ states:
     nextState: DetermineCompletion
 - name: DetermineCompletion
   type: SWITCH
-  choices:
+  conditions:
   - path: "$.jobstatus"
     value: SUCCEEDED
     operator: Equals
@@ -2026,7 +2026,7 @@ And for denied credit check, for example:
         {
             "name": "EvaluateDecision",
             "type": "SWITCH",
-            "choices": [
+            "conditions": [
                 {
                     "path": "$.creditCheck.decision",
                     "value": "Approved",
@@ -2113,7 +2113,7 @@ states:
     nextState: EvaluateDecision
 - name: EvaluateDecision
   type: SWITCH
-  choices:
+  conditions:
   - path: "$.creditCheck.decision"
     value: Approved
     operator: Equals

--- a/workflow/spec/roadmap.md
+++ b/workflow/spec/roadmap.md
@@ -46,4 +46,4 @@ _Status description:_
 | 🚩 | Decide on state/task/stage/step naming convention | [issue link](https://github.com/cncf/wg-serverless/issues/127) |
 | ✏️ | Finish specification primer document | [google doc](https://docs.google.com/document/d/11rD3Azj63G2Si0VpokSpr-1ib3mFRFHSwN6tJb-0LQM/edit#heading=h.paewfy83tetm) |
 | ✔ | Rename Relay to Inject state | spec doc](spec.md) |
-
+| ✏ | Update Switch State | |

--- a/workflow/spec/schema/serverless-workflow-schema.json
+++ b/workflow/spec/schema/serverless-workflow-schema.json
@@ -826,7 +826,7 @@
     },
     "switchstate": {
       "type": "object",
-      "description": "Permits transitions to other states based on criteria matching",
+      "description": "Permits transitions to other states based on condition matching",
       "properties": {
         "id": {
           "type": "string",
@@ -851,28 +851,12 @@
         "stateDataFilter": {
           "$ref": "#/definitions/statedatafilter"
         },
-        "choices": {
+        "conditions": {
           "type": "array",
-          "description": "Defines matching rules evaluated against state data",
+          "description": "Defines conditions evaluated against state data",
           "items": {
-            "anyOf": [
-              {
-                "title": "Single Choice",
-                "$ref": "#/definitions/singlechoice"
-              },
-              {
-                "title": "And Choice",
-                "$ref": "#/definitions/andchoice"
-              },
-              {
-                "title": "Not Choice",
-                "$ref": "#/definitions/notchoice"
-              },
-              {
-                "title": "Or Choice",
-                "$ref": "#/definitions/orchoice"
-              }
-            ]
+            "type": "object",
+            "$ref": "#/definitions/condition"
           }
         },
         "onError": {
@@ -884,7 +868,7 @@
           }
         },
         "default": {
-          "description": "Next transition of the workflow if there is no match for any choices",
+          "description": "Next transition of the workflow if there is no matching conditions",
           "$ref": "#/definitions/transition"
         },
         "dataInputSchema": {
@@ -906,7 +890,7 @@
           "required": [
             "name",
             "type",
-            "choices",
+            "conditions",
             "default"
           ]
         },
@@ -915,11 +899,38 @@
             "start",
             "name",
             "type",
-            "choices",
+            "conditions",
             "default"
           ]
         }
       ]
+    },
+    "condition": {
+      "type": "object",
+      "description": "Switch state condition",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "JSONPath expression that selects elements of state data"
+        },
+        "value": {
+          "type": "string",
+          "description": "Matching value"
+        },
+        "operator": {
+          "type" : "string",
+          "enum": ["Exists", "NotExists", "Null", "NotNull", "Equals", "NotEquals", "LessThan", "LessThanOrEquals", "GreaterThan", "GreaterThanOrEquals", "Matches", "NotMatches", "Custom"],
+          "description": "Condition operator"
+        },
+        "transition": {
+          "description": "Next transition of the workflow if there is valid matches",
+          "$ref": "#/definitions/transition"
+        }
+      },
+      "metadata": {
+        "$ref": "#/definitions/metadata"
+      },
+      "required": ["path", "value", "operator", "transition"]
     },
     "subflowstate": {
       "type": "object",
@@ -1405,118 +1416,6 @@
             "transition"
           ]
         }
-      ]
-    },
-    "defaultchoice": {
-      "type": "object",
-      "description": "Default Choice",
-      "properties": {
-        "path": {
-          "type": "string",
-          "description": "JSONPath that selects an element of state data"
-        },
-        "value": {
-          "type": "string",
-          "description": "Matching value"
-        },
-        "operator": {
-          "type": "string",
-          "enum": [
-            "Exists",
-            "Equals",
-            "LessThan",
-            "LessThanEquals",
-            "GreaterThan",
-            "GreaterThanEquals"
-          ],
-          "description": "Specifies how the input data is compared with the values"
-        }
-      },
-      "required": [
-        "path",
-        "value",
-        "operator"
-      ]
-    },
-    "singlechoice": {
-      "type": "object",
-      "description": "Single Choice",
-      "allOf": [
-        {
-          "$ref": "#/definitions/defaultchoice"
-        }
-      ],
-      "properties": {
-        "transition": {
-          "description": "Next transition of the workflow if there is a valid match",
-          "$ref": "#/definitions/transition"
-        }
-      },
-      "required": [
-        "transition"
-      ]
-    },
-    "andchoice": {
-      "type": "object",
-      "description": "And Choice",
-      "properties": {
-        "and": {
-          "type": "array",
-          "description": "List of choices",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/defaultchoice"
-          }
-        },
-        "transition": {
-          "description": "Next transition of the workflow if there is a valid match",
-          "$ref": "#/definitions/transition"
-        }
-      },
-      "required": [
-        "and",
-        "transition"
-      ]
-    },
-    "orchoice": {
-      "type": "object",
-      "description": "Or Choice",
-      "properties": {
-        "or": {
-          "type": "array",
-          "description": "List of choices",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/defaultchoice"
-          }
-        },
-        "transition": {
-          "description": "Next transition of the workflow if there is a valid match",
-          "$ref": "#/definitions/transition"
-        }
-      },
-      "required": [
-        "or",
-        "transition"
-      ]
-    },
-    "notchoice": {
-      "type": "object",
-      "description": "Not Choice",
-      "properties": {
-        "not": {
-          "type": "object",
-          "$ref": "#/definitions/defaultchoice",
-          "description": "Not Choice"
-        },
-        "transition": {
-          "description": "Next transition of the workflow if there is a valid match",
-          "$ref": "#/definitions/transition"
-        }
-      },
-      "required": [
-        "not",
-        "transition"
       ]
     },
     "expression": {


### PR DESCRIPTION
Updates Switch state:
* renames "choices" to "conditions"
* Removes the unnecessary "and "not" "or" choices and replaces them with condition definitions
* Adds more values as well as "Custom" value to condition operator
* Updates all examples

Reason: Our Switch state is very important state in spec however was way too complex to use. It acts as an exclusive gateway so the docs and its definition have been updated to clearly state its purpose. The different choices were not needed and just made things more complicated than should be, so they are removed.