### PR TITLE
Update state definitions table

### DIFF
--- a/workflow/spec/roadmap.md
+++ b/workflow/spec/roadmap.md
@@ -45,5 +45,5 @@ _Status description:_
 | 🚩 | Start discussions on Serverless Workflow Technology Compatibility Kit (TCK) | |
 | 🚩 | Decide on state/task/stage/step naming convention | [issue link](https://github.com/cncf/wg-serverless/issues/127) |
 | ✏️ | Finish specification primer document | [google doc](https://docs.google.com/document/d/11rD3Azj63G2Si0VpokSpr-1ib3mFRFHSwN6tJb-0LQM/edit#heading=h.paewfy83tetm) |
-| ✏ | Rename Relay to Inject state |  |
+| ✔ | Rename Relay to Inject state | spec doc](spec.md) |
 

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -432,17 +432,17 @@ to correlate multiple events that are needed to start a workflow instance.
 
 States define building blocks of the Serverless Workflow. The specification defines following states:
 
-| Name | Description | Consumes events? | Produces events? | Executes actions? | Handles errors? | Allows parallel execution? | Makes data-based transitions? |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| **[Event](#Event-State)** | Define events that trigger action execution | yes | yes | yes | yes (includes retries) | yes | no |
-| **[Operation](#Operation-State)** | Execute one or more actions | no | yes | yes | yes (includes retries) | yes | no |
-| **[Switch](#Switch-State)** | Define data-based workflow transitions | no | yes | no | yes | no | yes |
-| **[Delay](#Delay-State)** | Delay workflow execution | no | yes | no | yes | no | no |
-| **[Parallel](#Parallel-State)** | Causes parallel execution of branches (set of states) | no | yes | no | yes (includes retries) | yes | no |
-| **[SubFlow](#SubFlow-State)** | Represents the invocation of another workflow from within a workflow | no | yes | no | yes | no | no |
-| **[Inject](#Inject-State)** | Inject static data into state data | no | yes | no | yes | no | no |
-| **[ForEach](#ForEach-State)** | Parallel execution of states for each element of a data array | no | yes | no | yes (includes retries) | yes | no |
-| **[Callback](#Callback-State)** | Manual decision step. Executes a function and waits for callback event that indicates completion of the manual decision | yes | yes | yes (including retries) | yes | no | no |
+| Name | Description | Consumes events? | Produces events? | Executes actions? | Handles errors? | Allows parallel execution? | Makes data-based transitions? | Can be workflow start state? | Can be workflow end state? |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **[Event](#Event-State)** | Define events that trigger action execution | yes | yes | yes | yes (includes retries) | yes | no | yes | yes |
+| **[Operation](#Operation-State)** | Execute one or more actions | no | yes | yes | yes (includes retries) | yes | no | yes | yes |
+| **[Switch](#Switch-State)** | Define data-based workflow transitions | no | yes | no | yes | no | yes | yes | no |
+| **[Delay](#Delay-State)** | Delay workflow execution | no | yes | no | yes | no | no | yes | yes |
+| **[Parallel](#Parallel-State)** | Causes parallel execution of branches (set of states) | no | yes | no | yes (includes retries) | yes | no | yes | yes |
+| **[SubFlow](#SubFlow-State)** | Represents the invocation of another workflow from within a workflow | no | yes | no | yes | no | no | yes | yes |
+| **[Inject](#Inject-State)** | Inject static data into state data | no | yes | no | yes | no | no | yes | yes |
+| **[ForEach](#ForEach-State)** | Parallel execution of states for each element of a data array | no | yes | no | yes (includes retries) | yes | no | yes | yes |
+| **[Callback](#Callback-State)** | Manual decision step. Executes a function and waits for callback event that indicates completion of the manual decision | yes | yes | yes (including retries) | yes | no | no | yes | yes |
 
 Following is a detailed description of each of the defined states:
 


### PR DESCRIPTION
Updates the state definitions table:
* adds new column "Can be workflow start state"
* adds new column "Can be workflow end state"

This is to clearly show that switch state cannot be a workflow end state up-front in this table.