### PR TITLE
Parallel State - waitForCompletion update

### DIFF
--- a/workflow/spec/examples.md
+++ b/workflow/spec/examples.md
@@ -558,9 +558,8 @@ states:
 #### Description
 
 This example uses a parallel state to execute two branches (simple wait states) at the same time.
-Note that the waitForCompletion flag is set to "false" so as soon as the "ShortDelay" delay state finishes,
-the workflow complete execution. If waitForCompletion was set to true, the workflow would complete after both
-of the branches are done.
+The waitForCompletion flag is set to false, which means the parallel state has to wait for both branches
+to finish execution before it can transition (end workflow execution in this case as it is an end state).
 
 #### Workflow Definition
 
@@ -585,6 +584,7 @@ of the branches are done.
      "start": {
        "kind": "DEFAULT"
      },
+     "waitForCompletion": true,
      "branches": [
         {
           "name": "Branch1",
@@ -600,8 +600,7 @@ of the branches are done.
                    "kind": "DEFAULT"
                  }
             }
-          ],
-          "waitForCompletion": false
+          ]
         },
         {
           "name": "Branch2",
@@ -617,8 +616,7 @@ of the branches are done.
                     "kind": "DEFAULT"
                   }
              }
-          ],
-          "waitForCompletion": false
+          ]
         }
      ],
      "end": {
@@ -643,6 +641,7 @@ states:
   start:
     kind: DEFAULT
   branches:
+  waitForCompletion: true
   - name: Branch1
     states:
     - name: ShortDelay
@@ -652,7 +651,6 @@ states:
       timeDelay: PT15S
       end:
         kind: DEFAULT
-    waitForCompletion: false
   - name: Branch2
     states:
     - name: LongDelay
@@ -662,7 +660,6 @@ states:
       timeDelay: PT2M
       end:
         kind: DEFAULT
-    waitForCompletion: false
   end:
     kind: DEFAULT
 ```

--- a/workflow/spec/examples.md
+++ b/workflow/spec/examples.md
@@ -558,7 +558,7 @@ states:
 #### Description
 
 This example uses a parallel state to execute two branches (simple wait states) at the same time.
-The waitForCompletion flag is set to false, which means the parallel state has to wait for both branches
+The completionType type is set to "AND", which means the parallel state has to wait for both branches
 to finish execution before it can transition (end workflow execution in this case as it is an end state).
 
 #### Workflow Definition
@@ -584,7 +584,7 @@ to finish execution before it can transition (end workflow execution in this cas
      "start": {
        "kind": "DEFAULT"
      },
-     "waitForCompletion": true,
+     "completionType": "AND",
      "branches": [
         {
           "name": "Branch1",
@@ -641,7 +641,7 @@ states:
   start:
     kind: DEFAULT
   branches:
-  waitForCompletion: true
+  completionType: AND
   - name: Branch1
     states:
     - name: ShortDelay

--- a/workflow/spec/roadmap.md
+++ b/workflow/spec/roadmap.md
@@ -46,5 +46,7 @@ _Status description:_
 | 🚩 | Decide on state/task/stage/step naming convention | [issue link](https://github.com/cncf/wg-serverless/issues/127) |
 | ✏️ | Finish specification primer document | [google doc](https://docs.google.com/document/d/11rD3Azj63G2Si0VpokSpr-1ib3mFRFHSwN6tJb-0LQM/edit#heading=h.paewfy83tetm) |
 | ✔ | Rename Relay to Inject state | [spec doc](spec.md) |
-| ✏ | Update Switch State | [spec doc](spec.md) |
+| ✔ | Update Switch State | [spec doc](spec.md) |
 | ✔ | Rename Relay to Inject state | [spec doc](spec.md) |
+| ✔️| Update waitForCompletion property of Parallel State | [spec doc](spec.md) |
+

--- a/workflow/spec/schema/serverless-workflow-schema.json
+++ b/workflow/spec/schema/serverless-workflow-schema.json
@@ -361,11 +361,6 @@
               }
             ]
           }
-        },
-        "waitForCompletion": {
-          "type": "boolean",
-          "default": false,
-          "description": "Flow must wait for this branch to finish before continuing"
         }
       },
       "required": [
@@ -751,6 +746,11 @@
             "type": "object",
             "$ref": "#/definitions/branch"
           }
+        },
+        "waitForCompletion": {
+          "type": "boolean",
+          "default": true,
+          "description": "If true all branches must finish before state can transition. If false, workflow can transition as soon as all branches were triggered"
         },
         "retry": {
           "type": "array",

--- a/workflow/spec/schema/serverless-workflow-schema.json
+++ b/workflow/spec/schema/serverless-workflow-schema.json
@@ -747,10 +747,17 @@
             "$ref": "#/definitions/branch"
           }
         },
-        "waitForCompletion": {
-          "type": "boolean",
-          "default": true,
-          "description": "If true all branches must finish before state can transition. If false, workflow can transition as soon as all branches were triggered"
+        "completionType": {
+          "type" : "string",
+          "enum": ["AND", "XOR", "N_OF_M"],
+          "description": "Option types on how to complete branch execution.",
+          "default": "AND"
+        },
+        "n": {
+          "type": "integer",
+          "default": 0,
+          "minimum": 0,
+          "description": "Used when completionType is set to 'N_OF_M' to specify the 'N' value"
         },
         "retry": {
           "type": "array",

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1387,7 +1387,8 @@ Delay state waits for a certain amount of time before transitioning to a next st
 | name | State name | string | yes |
 | type | State type | string | yes |
 | [branches](#parallel-state-branch) | List of branches for this parallel state| array | yes |
-| waitForCompletion | If true all branches must finish before state can transition. If false, workflow can transition as soon as all branches were triggered. | boolean | no |
+| completionType | Option types on how to complete branch execution. | enum | no |
+| n | Used when branchCompletionType is set to 'N_OF_M' to specify the 'N' value. | integer | no |
 | [stateDataFilter](#state-data-filter) | State data filter | object | no |
 | [retry](#workflow-retrying) | States retry definitions | array | no |
 | [onError](#Workflow-Error-Handling) | States error handling definitions | array | no |
@@ -1427,10 +1428,17 @@ Delay state waits for a certain amount of time before transitioning to a next st
                 "$ref": "#/definitions/branch"
             }
         },
-        "waitForCompletion": {
-          "type": "boolean",
-          "default": true,
-          "description": "If true all branches must finish before state can transition. If false, workflow can transition as soon as all branches were triggered"
+        "completionType": {
+            "type" : "string",  
+            "enum": ["AND", "XOR", "N_OF_M"],
+            "description": "Option types on how to complete branch execution.",
+            "default": "AND"
+        },
+        "n": {
+           "type": "integer",
+            "default": 0,
+            "minimum": 0,
+            "description": "Used when completionType is set to 'N_OF_M' to specify the 'N' value"
         },
         "stateDataFilter": {
           "$ref": "#/definitions/statedatafilter"
@@ -1523,7 +1531,13 @@ Parallel state defines a collection of branches which are to be executed in para
 Branches contain one or more states. Each branch must define one [starting state](#Start-Definition) as well as 
 include at least one [end state](#End-Definition).
 
-The "waitForCompletion" property determines if all branches must complete execution before the state can transition.
+The "completionType" enum specifies the different ways of completing branch execution:
+* AND: All branches must complete execution before state can perform its transition
+* XOR: State can transition when one of the branches completes execution
+* N_OF_M: State can transition once N number of branches have completed execution. In this case you should also
+specify the "n" property to define this number.
+
+
 
 #### <a name="parallel-state-branch"></a>Parallel State: Branch
 
@@ -1595,9 +1609,6 @@ Each branch receives the same copy of the Parallel state's data input.
 States within each branch are only allowed to transition to states defined in the same branch.
 Transitions to other branches or workflow states are not allowed.
 States outside a parallel state cannot transition to a states declared within branches.
-
-If the parallel state "waitForCompletion" is set to true, the data output of the Parallel state includes the data output of each executed branch.
-If it is set to false, branch data outputs are not included into the Parallel state data output.
 
 #### SubFlow State
 

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1384,9 +1384,10 @@ Delay state waits for a certain amount of time before transitioning to a next st
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | id | Unique state id | string | no |
-| name |State name | string | yes |
-| type |State type | string | yes |
-| [branches](#parallel-state-branch) |List of branches for this parallel state| array | yes |
+| name | State name | string | yes |
+| type | State type | string | yes |
+| [branches](#parallel-state-branch) | List of branches for this parallel state| array | yes |
+| waitForCompletion | If true all branches must finish before state can transition. If false, workflow can transition as soon as all branches were triggered. | boolean | no |
 | [stateDataFilter](#state-data-filter) | State data filter | object | no |
 | [retry](#workflow-retrying) | States retry definitions | array | no |
 | [onError](#Workflow-Error-Handling) | States error handling definitions | array | no |
@@ -1425,6 +1426,11 @@ Delay state waits for a certain amount of time before transitioning to a next st
                 "type": "object",
                 "$ref": "#/definitions/branch"
             }
+        },
+        "waitForCompletion": {
+          "type": "boolean",
+          "default": true,
+          "description": "If true all branches must finish before state can transition. If false, workflow can transition as soon as all branches were triggered"
         },
         "stateDataFilter": {
           "$ref": "#/definitions/statedatafilter"
@@ -1514,7 +1520,10 @@ Delay state waits for a certain amount of time before transitioning to a next st
 </details>
 
 Parallel state defines a collection of branches which are to be executed in parallel.
-Branches contain one or more states. Each branch must define one [starting state](#Start-Definition) as well as include at least one [end state](#End-Definition).
+Branches contain one or more states. Each branch must define one [starting state](#Start-Definition) as well as 
+include at least one [end state](#End-Definition).
+
+The "waitForCompletion" property determines if all branches must complete execution before the state can transition.
 
 #### <a name="parallel-state-branch"></a>Parallel State: Branch
 
@@ -1522,7 +1531,6 @@ Branches contain one or more states. Each branch must define one [starting state
 | --- | --- | --- | --- |
 | name | Branch name | string | yes |
 | [states](#State-Definition) | States to be executed in this branch | array | yes |
-| waitForCompletion | If workflow execution must wait for this branch to finish before continuing | boolean | no |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -1575,11 +1583,6 @@ Branches contain one or more states. Each branch must define one [starting state
                             }
                         ]
                     }
-        },
-        "waitForCompletion": {
-            "type": "boolean",
-            "default": false,
-            "description": "Workflow execution must wait for this branch to finish before continuing"
         }
     },
     "required": ["name", "states"]
@@ -1593,10 +1596,8 @@ States within each branch are only allowed to transition to states defined in th
 Transitions to other branches or workflow states are not allowed.
 States outside a parallel state cannot transition to a states declared within branches.
 
-Data output of the Parallel state includes the data output of each executed branch.
-
-The "waitForCompletion" property allows the parallel state to manage branch executions.
-Parallel state must wait for all branches which have this property set to "true" before triggering a transition.
+If the parallel state "waitForCompletion" is set to true, the data output of the Parallel state includes the data output of each executed branch.
+If it is set to false, branch data outputs are not included into the Parallel state data output.
 
 #### SubFlow State
 


### PR DESCRIPTION
Moves the waitForCompletion property from branch to parallel state.
The parallel state itself needs to determine how to "join" branches, and not each branch itself.