### PR TITLE
Adding timeout property for actions

### DIFF
--- a/workflow/spec/roadmap.md
+++ b/workflow/spec/roadmap.md
@@ -49,4 +49,5 @@ _Status description:_
 | ✔ | Update Switch State | [spec doc](spec.md) |
 | ✔ | Rename Relay to Inject state | [spec doc](spec.md) |
 | ✔️| Update waitForCompletion property of Parallel State | [spec doc](spec.md) |
+| ✔️| Add timeout property to actions | [spec doc](spec.md) |
 

--- a/workflow/spec/schema/serverless-workflow-schema.json
+++ b/workflow/spec/schema/serverless-workflow-schema.json
@@ -237,6 +237,10 @@
           "description": "References a reusable function definition",
           "$ref": "#/definitions/functionref"
         },
+        "timeout": {
+          "type": "string",
+          "description": "Time period to wait for function execution to complete"
+        },
         "actionDataFilter": {
           "$ref": "#/definitions/actiondatafilter"
         }

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -730,6 +730,7 @@ instance in case it is an end state without performing any actions.
 | --- | --- | --- | --- |
 | name | Unique action name | string | no |
 | [functionRef](#FunctionRef-Definition) | References a reusable function definition | object | yes |
+| timeout | Time period to wait for function execution to complete (ISO 8601 format). For example: "PT15M" (15 minutes), or "P2DT3H4M" (2 days, 3 hours and 4 minutes)| string | no |
 | [actionDataFilter](#action-data-filter) | Action data filter definition | object | no |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
@@ -747,6 +748,10 @@ instance in case it is an end state without performing any actions.
             "$ref": "#/definitions/functionref",
             "description": "References a reusable function definition"
         },
+        "timeout": {
+          "type": "string",
+          "description": "Time period to wait for function execution to complete"
+        },
         "actionDataFilter": {
           "$ref": "#/definitions/actiondatafilter"
         }
@@ -758,6 +763,13 @@ instance in case it is an end state without performing any actions.
 </details>
 
 Actions reference a reusable function definition to be invoked when this action is executed.
+
+The "timeout" property defines the amount of time to wait for function execution to complete. It
+is described in ISO 8601 format, so for example "PT2M" would mean the maximum time for the function to complete
+its execution is two minutes. 
+If the set timeout period is exceeded, the state should handle this via its [retry and onError definitions](#workflow-retrying).
+In the case they are not defined, the state should proceed with transitioning to the next state, or ending 
+the workflow execution in case it is an end state. 
 
 #### FunctionRef Definition
 


### PR DESCRIPTION
Actions execute functions, which can time out. Adding timeout property so this can be handled with states retry/onError definitions.