### PR TITLE
Change all uppercase properties and enum types to lowercase

### DIFF
--- a/workflow/spec/examples-argo.md
+++ b/workflow/spec/examples-argo.md
@@ -85,16 +85,16 @@ functions:
     command: cowsay
 states:
 - name: whalesay
-  type: OPERATION
+  type: operation
   start:
-    kind: DEFAULT
+    kind: default
   actions:
   - functionRef:
       refName: whalesayimage
       parameters:
         message: "$.message"
   end:
-    kind: DEFAULT
+    kind: default
 ```
 
 </td>
@@ -172,9 +172,9 @@ functions:
     command: cowsay
 states:
 - name: hello1
-  type: OPERATION
+  type: operation
   start:
-    kind: DEFAULT
+    kind: default
   actions:
   - functionRef:
       refName: whalesayimage
@@ -183,37 +183,37 @@ states:
   transition:
     nextState: parallelhello
 - name: parallelhello
-  type: PARALLEL
-  completionType: AND
+  type: parallel
+  completionType: and
   branches:
   - name: hello2a-branch
     states:
     - name: hello2a
-      type: OPERATION
+      type: operation
       start:
-        kind: DEFAULT
+        kind: default
       actions:
       - functionRef:
           refName: whalesayimage
           parameters:
             message: hello2a
       end:
-        kind: DEFAULT
+        kind: default
   - name: hello2b-branch
     states:
     - name: hello2b
-      type: OPERATION
+      type: operation
       start:
-        kind: DEFAULT
+        kind: default
       actions:
       - functionRef:
           refName: whalesayimage
           parameters:
             message: hello2b
       end:
-        kind: DEFAULT
+        kind: default
   end:
-    kind: DEFAULT
+    kind: default
 
 ```
 
@@ -292,9 +292,9 @@ functions:
     command: '[echo, "{{inputs.parameters.message}}"]'
 states:
 - name: A
-  type: OPERATION
+  type: operation
   start:
-    kind: DEFAULT
+    kind: default
   actions:
   - functionRef:
       refName: echo
@@ -303,48 +303,48 @@ states:
   transition:
     nextState: parallelecho
 - name: parallelecho
-  type: PARALLEL
-  completionType: AND
+  type: parallel
+  completionType: and
   branches:
   - name: B-branch
     states:
     - name: B
-      type: OPERATION
+      type: operation
       start:
-        kind: DEFAULT
+        kind: default
       actions:
       - functionRef:
           refName: echo
           parameters:
             message: B
       end:
-        kind: DEFAULT
+        kind: default
   - name: C-branch
     states:
     - name: C
-      type: OPERATION
+      type: operation
       start:
-        kind: DEFAULT
+        kind: default
       actions:
       - functionRef:
           refName: echo
           parameters:
             message: C
       end:
-        kind: DEFAULT
+        kind: default
   transition:
     nextState: D
 - name: D
-  type: OPERATION
+  type: operation
   start:
-    kind: DEFAULT
+    kind: default
   actions:
   - functionRef:
       refName: echo
       parameters:
         message: D
   end:
-    kind: DEFAULT
+    kind: default
 ```
 
 </td>
@@ -457,9 +457,9 @@ functions:
     source: 'echo result was: {{inputs.parameters.message}}'
 states:
 - name: generate
-  type: OPERATION
+  type: operation
   start:
-    kind: DEFAULT
+    kind: default
   actions:
   - functionRef:
       refName: gen-random-int-bash
@@ -468,14 +468,14 @@ states:
   transition:
     nextState: print-message
 - name: print-message
-  type: OPERATION
+  type: operation
   actions:
   - functionRef:
       refName: printmessagefunc
       parameters:
         message: "$.results"
   end:
-    kind: DEFAULT
+    kind: default
 ```
 
 </td>
@@ -539,9 +539,9 @@ functions:
     command: cowsay
 states:
 - name: injectdata
-  type: INJECT
+  type: inject
   start:
-    kind: DEFAULT
+    kind: default
   data:
     greetings:
     - hello world
@@ -549,14 +549,14 @@ states:
   transition:
     nextState: printgreetings
 - name: printgreetings
-  type: FOREACH
+  type: foreach
   inputCollection: "$.greetings"
   inputParameter: "$.greeting"
   states:
   - name: foreach-print
-    type: OPERATION
+    type: operation
     start:
-      kind: DEFAULT
+      kind: default
     actions:
     - name: print-message
       functionRef:
@@ -564,9 +564,9 @@ states:
         parameters:
           message: "$.greeting"
     end:
-      kind: DEFAULT
+      kind: default
   end:
-    kind: DEFAULT
+    kind: default
 ```
 
 </td>
@@ -651,9 +651,9 @@ functions:
     command: sh, -c
 states:
 - name: flip-coin
-  type: OPERATION
+  type: operation
   start:
-    kind: DEFAULT
+    kind: default
   actions:
   - functionRef:
       refName: flip-coin-function
@@ -662,36 +662,36 @@ states:
   transition:
     nextState: show-flip-results
 - name: show-flip-results
-  type: SWITCH
+  type: switch
   dataConditions:
   - path: "$.flip.result"
     value: heads
-    operator: Equals
+    operator: equals
     transition:
       nextState: show-results-heads
   - path: "$.flip.result"
     value: tails
-    operator: Equals
+    operator: equals
     transition:
       nextState: show-results-tails
 - name: show-results-heads
-  type: OPERATION
+  type: operation
   actions:
   - functionRef:
       refName: echo
     actionDataFilter:
       dataResultsPath: it was heads
   end:
-    kind: DEFAULT
+    kind: default
 - name: show-results-tails
-  type: OPERATION
+  type: operation
   actions:
   - functionRef:
       refName: echo
     actionDataFilter:
       dataResultsPath: it was tails
   end:
-    kind: DEFAULT
+    kind: default
 ```
 
 </td>
@@ -749,9 +749,9 @@ functions:
     command: python
 states:
 - name: retry-backoff
-  type: OPERATION
+  type: operation
   start:
-    kind: DEFAULT
+    kind: default
   actions:
   - functionRef:
       refName: flip-coin-function
@@ -766,7 +766,7 @@ states:
     multiplier: PT2M
     interval: PT1M
   end:
-    kind: DEFAULT
+    kind: default
 ```
 
 </td>
@@ -844,9 +844,9 @@ functions:
     source: import random result = "heads" if random.randint(0,1) == 0 else "tail"  print(result)
 states:
 - name: flip-coin-state
-  type: OPERATION
+  type: operation
   start:
-    kind: DEFAULT
+    kind: default
   actions:
   - functionRef:
       refName: flip-coin-function
@@ -855,27 +855,27 @@ states:
   transition:
     nextState: flip-coin-check
 - name: flip-coin-check
-  type: SWITCH
+  type: switch
   dataConditions:
   - path: "$.steps.flip-coin.outputs.result"
     value: tails
-    operator: Equals
+    operator: equals
     transition:
       nextState: flip-coin-state
   - path: "$.steps.flip-coin.outputs.result"
     value: heads
-    operator: Equals
+    operator: equals
     transition:
       nextState: heads-state
 - name: heads-state
-  type: OPERATION
+  type: operation
   actions:
   - functionRef:
       refName: heads-function
       parameters:
         args: echo "it was heads"
   end:
-    kind: DEFAULT
+    kind: default
 ```
 
 </td>
@@ -973,9 +973,9 @@ functions:
     command: "[sh, -c]"
 states:
 - name: intentional-fail-state
-  type: OPERATION
+  type: operation
   start:
-    kind: DEFAULT
+    kind: default
   actions:
   - functionRef:
       refName: intentional-fail-function
@@ -990,7 +990,7 @@ states:
   transition:
     nextState: send-email-state
 - name: send-email-state
-  type: OPERATION
+  type: operation
   actions:
   - functionRef:
       refName: send-email-function
@@ -999,36 +999,36 @@ states:
   transition:
     nextState: emo-state
 - name: emo-state
-  type: SWITCH
+  type: switch
   dataConditions:
   - path: "$.exit-code"
     value: '1'
-    operator: Equals
+    operator: equals
     transition:
       nextState: celebrate-state
   - path: "$.exit-code"
     value: '1'
-    operator: NotEquals
+    operator: notequals
     transition:
       nextState: cry-state
 - name: celebrate-state
-  type: OPERATION
+  type: operation
   actions:
   - functionRef:
       refName: celebrate-cry-function
       parameters:
         args: echo hooray!
   end:
-    kind: DEFAULT
+    kind: default
 - name: cry-state
-  type: OPERATION
+  type: operation
   actions:
   - functionRef:
       refName: celebrate-cry-function
       parameters:
         args: echo boohoo!
   end:
-    kind: DEFAULT
+    kind: default
 ```
 
 </td>

--- a/workflow/spec/examples.md
+++ b/workflow/spec/examples.md
@@ -56,9 +56,9 @@ value of the "result" property. Since it is an end state, it's data output becom
 "states":[  
   {  
      "name":"Hello",
-     "type":"INJECT",
+     "type":"inject",
      "start": {
-       "kind": "DEFAULT"
+       "kind": "default"
      },
      "data": {
         "result": "Hello"
@@ -69,7 +69,7 @@ value of the "result" property. Since it is an end state, it's data output becom
   },
   {  
      "name":"World",
-     "type":"INJECT",
+     "type":"inject",
      "data": {
         "result": " World!"
      },
@@ -77,7 +77,7 @@ value of the "result" property. Since it is an end state, it's data output becom
        "dataOutputPath": "$.result"
      },
      "end": {
-       "kind": "DEFAULT"
+       "kind": "default"
      }
   }
 ]
@@ -94,21 +94,21 @@ name: Hello World Workflow
 description: Static Hello World
 states:
 - name: Hello
-  type: INJECT
+  type: inject
   start:
-    kind: DEFAULT
+    kind: default
   data:
     result: Hello
   transition:
     nextState: World
 - name: World
-  type: INJECT
+  type: inject
   data:
     result: " World!"
   stateDataFilter:
     dataOutputPath: "$.result"
   end:
-    kind: DEFAULT
+    kind: default
 ```
 
 </td>
@@ -179,11 +179,11 @@ becomes the workflow data output (as it is an end state):
 "states":[  
   {  
      "name":"Greet",
-     "type":"OPERATION",
+     "type":"operation",
      "start": {
-       "kind": "DEFAULT"
+       "kind": "default"
      },
-     "actionMode":"SEQUENTIAL",
+     "actionMode":"sequential",
      "actions":[  
         {  
            "functionRef": {
@@ -201,7 +201,7 @@ becomes the workflow data output (as it is an end state):
         "dataOutputPath": "$.greeting"
      },
      "end": {
-       "kind": "DEFAULT"
+       "kind": "default"
      }
   }
 ]
@@ -221,10 +221,10 @@ functions:
   resource: functionResourse
 states:
 - name: Greet
-  type: OPERATION
+  type: operation
   start:
-    kind: DEFAULT
-  actionMode: SEQUENTIAL
+    kind: default
+  actionMode: sequential
   actions:
   - functionRef:
       refName: greetingFunction
@@ -235,7 +235,7 @@ states:
   stateDataFilter:
     dataOutputPath: "$.greeting"
   end:
-    kind: DEFAULT
+    kind: default
 ```
 
 </td>
@@ -342,9 +342,9 @@ filters what is selected to be the state data output which then becomes the work
 "states":[  
   {  
      "name":"Greet",
-     "type":"EVENT",
+     "type":"event",
      "start": {
-       "kind": "DEFAULT"
+       "kind": "default"
      },
      "eventsActions": [{
          "eventRefs": ["GreetingEvent"],
@@ -366,7 +366,7 @@ filters what is selected to be the state data output which then becomes the work
         "dataOutputPath": "$.payload.greeting"
      },
      "end": {
-       "kind": "DEFAULT"
+       "kind": "default"
      }
   }
 ]
@@ -390,9 +390,9 @@ functions:
   resource: functionResourse
 states:
 - name: Greet
-  type: EVENT
+  type: event
   start:
-    kind: DEFAULT
+    kind: default
   eventsActions:
   - eventRefs:
     - GreetingEvent
@@ -406,7 +406,7 @@ states:
   stateDataFilter:
     dataOutputPath: "$.payload.greeting"
   end:
-    kind: DEFAULT
+    kind: default
 ```
 
 </td>
@@ -466,20 +466,20 @@ result of the workflow execution.
 {
  "name":"Solve",
  "start": {
-  "kind": "DEFAULT"
+  "kind": "default"
 },
- "type":"FOREACH",
+ "type":"foreach",
  "inputCollection": "$.expressions",
  "inputParameter": "$.singleexpression",
  "outputCollection": "$.results",
  "states": [
 {  
     "name":"GetResults",
-    "type":"OPERATION",
+    "type":"operation",
      "start": {
-       "kind": "DEFAULT"
+       "kind": "default"
     },
-    "actionMode":"SEQUENTIAL",
+    "actionMode":"sequential",
     "actions":[  
        {  
           "functionRef": {
@@ -491,7 +491,7 @@ result of the workflow execution.
        }
     ],
     "end": {
-      "kind": "DEFAULT"
+      "kind": "default"
     }
 }
  ],
@@ -499,7 +499,7 @@ result of the workflow execution.
     "dataOutputPath": "$.results"
  },
  "end": {
-   "kind": "DEFAULT"
+   "kind": "default"
  }
 }
 ]
@@ -520,28 +520,28 @@ functions:
 states:
 - name: Solve
   start:
-    kind: DEFAULT
-  type: FOREACH
+    kind: default
+  type: foreach
   inputCollection: "$.expressions"
   inputParameter: "$.singleexpression"
   outputCollection: "$.results"
   states:
   - name: GetResults
-    type: OPERATION
+    type: operation
     start:
-      kind: DEFAULT
-    actionMode: SEQUENTIAL
+      kind: default
+    actionMode: sequential
     actions:
     - functionRef:
         refName: solveMathExpressionFunction
         parameters:
           expression: "$.singleexpression"
     end:
-      kind: DEFAULT
+      kind: default
   stateDataFilter:
     dataOutputPath: "$.results"
   end:
-    kind: DEFAULT
+    kind: default
 ```
 
 </td>
@@ -559,7 +559,7 @@ states:
 #### Description
 
 This example uses a parallel state to execute two branches (simple wait states) at the same time.
-The completionType type is set to "AND", which means the parallel state has to wait for both branches
+The completionType type is set to "and", which means the parallel state has to wait for both branches
 to finish execution before it can transition (end workflow execution in this case as it is an end state).
 
 #### Workflow Definition
@@ -581,24 +581,24 @@ to finish execution before it can transition (end workflow execution in this cas
 "states":[  
   {  
      "name":"ParallelExec",
-     "type":"PARALLEL",
+     "type":"parallel",
      "start": {
-       "kind": "DEFAULT"
+       "kind": "default"
      },
-     "completionType": "AND",
+     "completionType": "and",
      "branches": [
         {
           "name": "Branch1",
           "states": [
             {
                 "name":"ShortDelay",
-                 "type":"DELAY",
+                 "type":"delay",
                  "start": {
-                    "kind": "DEFAULT"
+                    "kind": "default"
                 },
                  "timeDelay": "PT15S",
                  "end": {
-                   "kind": "DEFAULT"
+                   "kind": "default"
                  }
             }
           ]
@@ -608,20 +608,20 @@ to finish execution before it can transition (end workflow execution in this cas
           "states": [
              {
                  "name":"LongDelay",
-                  "type":"DELAY",
+                  "type":"delay",
                   "start": {
-                     "kind": "DEFAULT"
+                     "kind": "default"
                   },
                   "timeDelay": "PT2M",
                   "end": {
-                    "kind": "DEFAULT"
+                    "kind": "default"
                   }
              }
           ]
         }
      ],
      "end": {
-       "kind": "DEFAULT"
+       "kind": "default"
      }
   }
 ]
@@ -638,31 +638,31 @@ name: Parallel Execution Workflow
 description: Executes two branches in parallel
 states:
 - name: ParallelExec
-  type: PARALLEL
+  type: parallel
   start:
-    kind: DEFAULT
+    kind: default
   branches:
-  completionType: AND
+  completionType: and
   - name: Branch1
     states:
     - name: ShortDelay
-      type: DELAY
+      type: delay
       start:
-        kind: DEFAULT
+        kind: default
       timeDelay: PT15S
       end:
-        kind: DEFAULT
+        kind: default
   - name: Branch2
     states:
     - name: LongDelay
-      type: DELAY
+      type: delay
       start:
-        kind: DEFAULT
+        kind: default
       timeDelay: PT2M
       end:
-        kind: DEFAULT
+        kind: default
   end:
-    kind: DEFAULT
+    kind: default
 ```
 
 </td>
@@ -717,9 +717,9 @@ period, the workflow transitions to the "HandleNoVisaDecision" state.
 "states":[  
   {  
      "name":"CheckVisaStatus",
-     "type":"SWITCH",
+     "type":"switch",
      "start": {
-        "kind": "DEFAULT"
+        "kind": "default"
      },
      "eventConditions": [
         {
@@ -742,26 +742,26 @@ period, the workflow transitions to the "HandleNoVisaDecision" state.
   },
   {
     "name": "HandleApprovedVisa",
-    "type": "SUBFLOW",
+    "type": "subflow",
     "workflowId": "handleApprovedVisaWorkflowID",
     "end": {
-      "kind": "DEFAULT"
+      "kind": "default"
     }
   },
   {
       "name": "HandleRejectedVisa",
-      "type": "SUBFLOW",
+      "type": "subflow",
       "workflowId": "handleRejectedVisaWorkflowID",
       "end": {
-        "kind": "DEFAULT"
+        "kind": "default"
       }
   },
   {
       "name": "HandleNoVisaDecision",
-      "type": "SUBFLOW",
+      "type": "subflow",
       "workflowId": "handleNoVisaDecisionWorkfowId",
       "end": {
-        "kind": "DEFAULT"
+        "kind": "default"
       }
   }
 ]
@@ -872,15 +872,15 @@ If the applicants age is over 18 we start the application (subflow state). Other
    "states":[  
       {  
          "name":"CheckApplication",
-         "type":"SWITCH",
+         "type":"switch",
          "start": {
-            "kind": "DEFAULT"
+            "kind": "default"
          },
          "dataConditions": [
             {
               "path": "$.applicant.age",
               "value": "18",
-              "operator": "GreaterThanOrEquals",
+              "operator": "greaterthanorequals",
               "transition": {
                 "nextState": "StartApplication"
               }
@@ -888,7 +888,7 @@ If the applicants age is over 18 we start the application (subflow state). Other
             {
               "path": "$.applicant.age",
               "value": "18",
-              "operator": "LessThan",
+              "operator": "lessthan",
               "transition": {
                 "nextState": "RejectApplication"
               }
@@ -900,16 +900,16 @@ If the applicants age is over 18 we start the application (subflow state). Other
       },
       {
         "name": "StartApplication",
-        "type": "SUBFLOW",
+        "type": "subflow",
         "workflowId": "startApplicationWorkflowId",
         "end": {
-          "kind": "DEFAULT"
+          "kind": "default"
         }
       },
       {  
         "name":"RejectApplication",
-        "type":"OPERATION",
-        "actionMode":"SEQUENTIAL",
+        "type":"operation",
+        "actionMode":"sequential",
         "actions":[  
            {  
               "functionRef": {
@@ -921,7 +921,7 @@ If the applicants age is over 18 we start the application (subflow state). Other
            }
         ],
         "end": {
-          "kind": "DEFAULT"
+          "kind": "default"
         }
     }
    ]
@@ -941,37 +941,37 @@ functions:
   resource: functionResourse
 states:
 - name: CheckApplication
-  type: SWITCH
+  type: switch
   start:
-    kind: DEFAULT
+    kind: default
   dataConditions:
   - path: "$.applicant.age"
     value: '18'
-    operator: GreaterThanOrEquals
+    operator: greaterthanorequals
     transition:
       nextState: StartApplication
   - path: "$.applicant.age"
     value: '18'
-    operator: LessThan
+    operator: lessthan
     transition:
       nextState: RejectApplication
   default:
     nextState: RejectApplication
 - name: StartApplication
-  type: SUBFLOW
+  type: subflow
   workflowId: startApplicationWorkflowId
   end:
-    kind: DEFAULT
+    kind: default
 - name: RejectApplication
-  type: OPERATION
-  actionMode: SEQUENTIAL
+  type: operation
+  actionMode: sequential
   actions:
   - functionRef:
       refName: sendRejectionEmailFunction
       parameters:
         applicant: "$.applicant"
   end:
-    kind: DEFAULT
+    kind: default
 ```
 
 </td>
@@ -1033,11 +1033,11 @@ The data output of the workflow contains the information of the exception caught
 "states":[  
   {  
     "name":"ProvisionOrder",
-    "type":"OPERATION",
+    "type":"operation",
     "start": {
-      "kind": "DEFAULT"
+      "kind": "default"
     },
-    "actionMode":"SEQUENTIAL",
+    "actionMode":"sequential",
     "actions":[  
        {  
           "functionRef": {
@@ -1086,34 +1086,34 @@ The data output of the workflow contains the information of the exception caught
 },
 {
    "name": "MissingId",
-   "type": "SUBFLOW",
+   "type": "subflow",
    "workflowId": "handleMissingIdExceptionWorkflow",
    "end": {
-     "kind": "DEFAULT"
+     "kind": "default"
    }
 },
 {
    "name": "MissingItem",
-   "type": "SUBFLOW",
+   "type": "subflow",
    "workflowId": "handleMissingItemExceptionWorkflow",
    "end": {
-     "kind": "DEFAULT"
+     "kind": "default"
    }
 },
 {
    "name": "MissingQuantity",
-   "type": "SUBFLOW",
+   "type": "subflow",
    "workflowId": "handleMissingQuantityExceptionWorkflow",
    "end": {
-     "kind": "DEFAULT"
+     "kind": "default"
    }
 },
 {
    "name": "ApplyOrder",
-   "type": "SUBFLOW",
+   "type": "subflow",
    "workflowId": "applyOrderWorkflowId",
    "end": {
-     "kind": "DEFAULT"
+     "kind": "default"
    }
 }
 ]
@@ -1133,10 +1133,10 @@ functions:
   resource: functionResourse
 states:
 - name: ProvisionOrder
-  type: OPERATION
+  type: operation
   start:
-    kind: DEFAULT
-  actionMode: SEQUENTIAL
+    kind: default
+  actionMode: sequential
   actions:
   - functionRef:
       refName: provisionOrderFunction
@@ -1163,25 +1163,25 @@ states:
   transition:
     nextState: ApplyOrder
 - name: MissingId
-  type: SUBFLOW
+  type: subflow
   workflowId: handleMissingIdExceptionWorkflow
   end:
-    kind: DEFAULT
+    kind: default
 - name: MissingItem
-  type: SUBFLOW
+  type: subflow
   workflowId: handleMissingItemExceptionWorkflow
   end:
-    kind: DEFAULT
+    kind: default
 - name: MissingQuantity
-  type: SUBFLOW
+  type: subflow
   workflowId: handleMissingQuantityExceptionWorkflow
   end:
-    kind: DEFAULT
+    kind: default
 - name: ApplyOrder
-  type: SUBFLOW
+  type: subflow
   workflowId: applyOrderWorkflowId
   end:
-    kind: DEFAULT
+    kind: default
 ```
 
 </td>
@@ -1246,11 +1246,11 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
   "states":[  
     {  
       "name":"SubmitJob",
-      "type":"OPERATION",
+      "type":"operation",
       "start": {
-         "kind": "DEFAULT"
+         "kind": "default"
       },
-      "actionMode":"SEQUENTIAL",
+      "actionMode":"sequential",
       "actions":[  
       {  
           "functionRef": {
@@ -1287,15 +1287,15 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
   },
   {
       "name": "SubmitError",
-      "type": "SUBFLOW",
+      "type": "subflow",
       "workflowId": "handleJobSubmissionErrorWorkflow",
       "end": {
-        "kind": "DEFAULT"
+        "kind": "default"
       }
   },
   {
       "name": "WaitForCompletion",
-      "type": "DELAY",
+      "type": "delay",
       "timeDelay": "PT5S",
       "transition": {
         "nextState":"GetJobStatus"
@@ -1303,8 +1303,8 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
   },
   {  
       "name":"GetJobStatus",
-      "type":"OPERATION",
-      "actionMode":"SEQUENTIAL",
+      "type":"operation",
+      "actionMode":"sequential",
       "actions":[  
       {  
         "functionRef": {
@@ -1327,12 +1327,12 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
   },
   {  
     "name":"DetermineCompletion",
-    "type":"SWITCH",
+    "type":"switch",
     "dataConditions": [
       {
         "path": "$.jobstatus",
         "value": "SUCCEEDED",
-        "operator": "Equals",
+        "operator": "equals",
         "transition": {
           "nextState": "JobSucceeded"
         }
@@ -1340,7 +1340,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
       {
         "path": "$.jobstatus",
         "value": "FAILED",
-        "operator": "Equals",
+        "operator": "equals",
         "transition": {
           "nextState": "JobFailed"
         }
@@ -1352,8 +1352,8 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
   },
   {  
       "name":"JobSucceeded",
-      "type":"OPERATION",
-      "actionMode":"SEQUENTIAL",
+      "type":"operation",
+      "actionMode":"sequential",
       "actions":[  
       {  
         "functionRef": {
@@ -1365,13 +1365,13 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
       }
       ],
       "end": {
-        "kind": "DEFAULT"
+        "kind": "default"
       }
   },
   {  
     "name":"JobFailed",
-    "type":"OPERATION",
-    "actionMode":"SEQUENTIAL",
+    "type":"operation",
+    "actionMode":"sequential",
     "actions":[  
     {  
         "functionRef": {
@@ -1383,7 +1383,7 @@ In the case job submission raises a runtime error, we transition to a SubFlow st
     }
     ],
     "end": {
-      "kind": "DEFAULT"
+      "kind": "default"
     }
   }
   ]
@@ -1409,10 +1409,10 @@ functions:
   resource: reportJobFailedResource
 states:
 - name: SubmitJob
-  type: OPERATION
+  type: operation
   start:
-    kind: DEFAULT
-  actionMode: SEQUENTIAL
+    kind: default
+  actionMode: sequential
   actions:
   - functionRef:
       refName: submitJob
@@ -1433,18 +1433,18 @@ states:
   transition:
     nextState: WaitForCompletion
 - name: SubmitError
-  type: SUBFLOW
+  type: subflow
   workflowId: handleJobSubmissionErrorWorkflow
   end:
-    kind: DEFAULT
+    kind: default
 - name: WaitForCompletion
-  type: DELAY
+  type: delay
   timeDelay: PT5S
   transition:
     nextState: GetJobStatus
 - name: GetJobStatus
-  type: OPERATION
-  actionMode: SEQUENTIAL
+  type: operation
+  actionMode: sequential
   actions:
   - functionRef:
       refName: checkJobStatus
@@ -1457,40 +1457,40 @@ states:
   transition:
     nextState: DetermineCompletion
 - name: DetermineCompletion
-  type: SWITCH
+  type: switch
   dataConditions:
   - path: "$.jobstatus"
     value: SUCCEEDED
-    operator: Equals
+    operator: equals
     transition:
       nextState: JobSucceeded
   - path: "$.jobstatus"
     value: FAILED
-    operator: Equals
+    operator: equals
     transition:
       nextState: JobFailed
   default:
     nextState: WaitForCompletion
 - name: JobSucceeded
-  type: OPERATION
-  actionMode: SEQUENTIAL
+  type: operation
+  actionMode: sequential
   actions:
   - functionRef:
       refName: reportJobSuceeded
       parameters:
         name: "$.jobuid"
   end:
-    kind: DEFAULT
+    kind: default
 - name: JobFailed
-  type: OPERATION
-  actionMode: SEQUENTIAL
+  type: operation
+  actionMode: sequential
   actions:
   - functionRef:
       refName: reportJobFailed
       parameters:
         name: "$.jobuid"
   end:
-    kind: DEFAULT
+    kind: default
 ```
 
 </td>
@@ -1540,7 +1540,7 @@ used is assumed to have the following results:
 ```
 
 After orders have been provisioned the ForEach states defines the end property which stops workflow execution.
-It defines its end definition to be of type "EVENT" in which case a CloudEvent will be produced which can be consumed
+It defines its end definition to be of type "event" in which case a CloudEvent will be produced which can be consumed
 by other orchestration workflows or other interested consumers. 
 Note that we define the event to be produced in the workflows "events" property.
 The data attached to the event contains the information on provisioned orders by this workflow. So the produced
@@ -1598,9 +1598,9 @@ CloudEvent upon completion of the workflow could look like:
 "states": [
 {
     "name": "ProvisionOrdersState",
-    "type": "FOREACH",
+    "type": "foreach",
     "start": {
-       "kind": "DEFAULT"
+       "kind": "default"
     },
     "inputCollection": "$.orders",
     "inputParameter": "$.singleorder",
@@ -1608,11 +1608,11 @@ CloudEvent upon completion of the workflow could look like:
     "states": [
     {
         "name": "DoProvision",
-        "type": "OPERATION",
+        "type": "operation",
         "start": {
-          "kind": "DEFAULT"
+          "kind": "default"
         },
-        "actionMode": "SEQUENTIAL",
+        "actionMode": "sequential",
         "actions": [
         {
             "functionRef": {
@@ -1624,7 +1624,7 @@ CloudEvent upon completion of the workflow could look like:
         }
         ],
         "end": {
-            "kind": "DEFAULT"
+            "kind": "default"
         }
     }
     ],
@@ -1632,7 +1632,7 @@ CloudEvent upon completion of the workflow could look like:
         "dataOutputPath": "$.provisionedOrders"
     },
     "end": {
-        "kind": "EVENT",
+        "kind": "event",
         "produceEvent": {
             "eventRef": "provisioningCompleteEvent",
             "data": "$.provisionedOrders"
@@ -1659,29 +1659,29 @@ functions:
   resource: functionResourse
 states:
 - name: ProvisionOrdersState
-  type: FOREACH
+  type: foreach
   start:
-    kind: DEFAULT
+    kind: default
   inputCollection: "$.orders"
   inputParameter: "$.singleorder"
   outputCollection: "$.results"
   states:
   - name: DoProvision
-    type: OPERATION
+    type: operation
     start:
-      kind: DEFAULT
-    actionMode: SEQUENTIAL
+      kind: default
+    actionMode: sequential
     actions:
     - functionRef:
         refName: provisionOrderFunction
         parameters:
           order: "$.order"
     end:
-      kind: DEFAULT
+      kind: default
   stateDataFilter:
     dataOutputPath: "$.provisionedOrders"
   end:
-    kind: EVENT
+    kind: event
     produceEvent:
       eventRef: provisioningCompleteEvent
       data: "$.provisionedOrders"
@@ -1784,9 +1784,9 @@ have the matching patient id.
 "states": [
 {
 "name": "MonitorVitals",
-"type": "EVENT",
+"type": "event",
 "start": {
-    "kind": "DEFAULT"
+    "kind": "default"
 },
 "exclusive": true,
 "eventsActions": [{
@@ -1824,7 +1824,7 @@ have the matching patient id.
     }
 ],
 "end": {
-    "kind": "TERMINATE"
+    "kind": "terminate"
 }
 }]
 }
@@ -1862,9 +1862,9 @@ functions:
   resource: callNurseResource
 states:
 - name: MonitorVitals
-  type: EVENT
+  type: event
   start:
-    kind: DEFAULT
+    kind: default
   exclusive: true
   eventsActions:
   - eventRefs:
@@ -1889,7 +1889,7 @@ states:
         parameters:
           patientid: "$.patientId"
   end:
-    kind: TERMINATE
+    kind: terminate
 ```
 
 </td>
@@ -1961,9 +1961,9 @@ when all three of these events happened (in no particular order).
 "states": [
 {
     "name": "FinalizeApplication",
-    "type": "EVENT",
+    "type": "event",
     "start": {
-       "kind": "DEFAULT"
+       "kind": "default"
     },
     "exclusive": false,
     "eventsActions": [
@@ -1986,7 +1986,7 @@ when all three of these events happened (in no particular order).
         }
     ],
     "end": {
-        "kind": "TERMINATE"
+        "kind": "terminate"
     }
 }
 ]
@@ -2019,9 +2019,9 @@ functions:
   resource: finalizeApplicationResource
 states:
 - name: FinalizeApplication
-  type: EVENT
+  type: event
   start:
-    kind: DEFAULT
+    kind: default
   exclusive: false
   eventsActions:
   - eventRefs:
@@ -2034,7 +2034,7 @@ states:
         parameters:
           student: "$.applicantId"
   end:
-    kind: TERMINATE
+    kind: terminate
 ```
 
 </td>
@@ -2154,9 +2154,9 @@ And for denied credit check, for example:
     "states": [
         {
             "name": "CheckCredit",
-            "type": "CALLBACK",
+            "type": "callback",
             "start": {
-               "kind": "DEFAULT"
+               "kind": "default"
             },
             "action": {
                 "functionRef": {
@@ -2174,12 +2174,12 @@ And for denied credit check, for example:
         },
         {
             "name": "EvaluateDecision",
-            "type": "SWITCH",
+            "type": "switch",
             "dataConditions": [
                 {
                     "path": "$.creditCheck.decision",
                     "value": "Approved",
-                    "operator": "Equals",
+                    "operator": "equals",
                     "transition": {
                         "nextState": "StartApplication"
                     }
@@ -2187,7 +2187,7 @@ And for denied credit check, for example:
                 {
                     "path": "$.creditCheck.decision",
                     "value": "Denied",
-                    "operator": "Equals",
+                    "operator": "equals",
                     "transition": {
                         "nextState": "RejectApplication"
                     }
@@ -2199,16 +2199,16 @@ And for denied credit check, for example:
         },
         {
             "name": "StartApplication",
-            "type": "SUBFLOW",
+            "type": "subflow",
             "workflowId": "startApplicationWorkflowId",
             "end": {
-                "kind": "DEFAULT"
+                "kind": "default"
             }
         },
         {
             "name": "RejectApplication",
-            "type": "OPERATION",
-            "actionMode": "SEQUENTIAL",
+            "type": "operation",
+            "actionMode": "sequential",
             "actions": [
                 {
                     "functionRef": {
@@ -2220,7 +2220,7 @@ And for denied credit check, for example:
                 }
             ],
             "end": {
-                "kind": "DEFAULT"
+                "kind": "default"
             }
         }
     ]
@@ -2248,9 +2248,9 @@ events:
   correlationToken: customerId
 states:
 - name: CheckCredit
-  type: CALLBACK
+  type: callback
   start:
-    kind: DEFAULT
+    kind: default
   action:
     functionRef:
       refName: callCreditCheckMicroservice
@@ -2261,35 +2261,35 @@ states:
   transition:
     nextState: EvaluateDecision
 - name: EvaluateDecision
-  type: SWITCH
+  type: switch
   dataConditions:
   - path: "$.creditCheck.decision"
     value: Approved
-    operator: Equals
+    operator: equals
     transition:
       nextState: StartApplication
   - path: "$.creditCheck.decision"
     value: Denied
-    operator: Equals
+    operator: equals
     transition:
       nextState: RejectApplication
   default:
     nextState: RejectApplication
 - name: StartApplication
-  type: SUBFLOW
+  type: subflow
   workflowId: startApplicationWorkflowId
   end:
-    kind: DEFAULT
+    kind: default
 - name: RejectApplication
-  type: OPERATION
-  actionMode: SEQUENTIAL
+  type: operation
+  actionMode: sequential
   actions:
   - functionRef:
       refName: sendRejectionEmailFunction
       parameters:
         applicant: "$.customer"
   end:
-    kind: DEFAULT
+    kind: default
 ```
 
 </td>
@@ -2367,9 +2367,9 @@ Bidding is done via an online application and bids are received as events are as
     "states": [
         {
           "name": "StoreCarAuctionBid",
-          "type": "EVENT",
+          "type": "event",
           "start": {
-              "kind": "SCHEDULED",
+              "kind": "scheduled",
               "schedule": {
                 "interval": "2020-03-20T09:00:00Z/2020-03-20T15:00:00Z"
               }
@@ -2389,7 +2389,7 @@ Bidding is done via an online application and bids are received as events are as
             }
           ],
           "end": {
-              "kind": "TERMINATE"
+              "kind": "terminate"
           }
         }
     ]
@@ -2414,9 +2414,9 @@ events:
   source: carBidEventSource
 states:
 - name: StoreCarAuctionBid
-  type: EVENT
+  type: event
   start:
-    kind: SCHEDULED
+    kind: scheduled
     schedule:
       interval: 2020-03-20T09:00:00Z/2020-03-20T15:00:00Z
   exclusive: true
@@ -2429,7 +2429,7 @@ states:
         parameters:
           bid: "$.bid"
   end:
-    kind: TERMINATE
+    kind: terminate
 ```
 
 </td>

--- a/workflow/spec/extending.md
+++ b/workflow/spec/extending.md
@@ -45,9 +45,9 @@ So let's define a simple example workflow model and then add our custom extensio
    "states":[  
       {  
          "name":"FirstOperation",
-         "type":"OPERATION",
+         "type":"operation",
          "start": {
-            "kind": "DEFAULT"
+            "kind": "default"
          },
          "actionMode":"Sequential",
          "actions":[  
@@ -64,9 +64,9 @@ So let's define a simple example workflow model and then add our custom extensio
       },
       {  
          "name":"SecondOperation",
-         "type":"OPERATION",
+         "type":"operation",
          "end": {
-           "kind": "DEFAULT"
+           "kind": "default"
          },
          "actionMode":"Sequential",
          "actions":[  

--- a/workflow/spec/roadmap.md
+++ b/workflow/spec/roadmap.md
@@ -54,4 +54,4 @@ _Status description:_
 | ✔️| Add event-based condition capabilities to Switch State | [spec doc](spec.md) |
 | ✔️| Add examples comparing Brigade workflow and spec markups | [examples doc](examples-brigade.md) |
 | ✔️| Update produceEvent data property | [spec doc](spec.md) |
-
+| ✔️| Change uppercase property and enum types to lowercase | [spec doc](spec.md) |

--- a/workflow/spec/schema/serverless-workflow-schema.json
+++ b/workflow/spec/schema/serverless-workflow-schema.json
@@ -207,11 +207,11 @@
         "actionMode": {
           "type": "string",
           "enum": [
-            "SEQUENTIAL",
-            "PARALLEL"
+            "sequential",
+            "parallel"
           ],
           "description": "Specifies how actions are to be performed (in sequence of parallel)",
-          "default": "SEQUENTIAL"
+          "default": "sequential"
         },
         "actions": {
           "type": "array",
@@ -392,7 +392,7 @@
         "type": {
           "type": "string",
           "enum": [
-            "DELAY"
+            "delay"
           ],
           "description": "State type"
         },
@@ -490,7 +490,7 @@
         "type": {
           "type": "string",
           "enum": [
-            "EVENT"
+            "event"
           ],
           "description": "State type"
         },
@@ -609,7 +609,7 @@
         "type": {
           "type": "string",
           "enum": [
-            "OPERATION"
+            "operation"
           ],
           "description": "State type"
         },
@@ -627,11 +627,11 @@
         "actionMode": {
           "type": "string",
           "enum": [
-            "SEQUENTIAL",
-            "PARALLEL"
+            "sequential",
+            "parallel"
           ],
           "description": "Specifies whether actions are performed in sequence or in parallel",
-          "default": "SEQUENTIAL"
+          "default": "sequential"
         },
         "actions": {
           "type": "array",
@@ -732,7 +732,7 @@
         "type": {
           "type": "string",
           "enum": [
-            "PARALLEL"
+            "parallel"
           ],
           "description": "State type"
         },
@@ -757,15 +757,15 @@
         },
         "completionType": {
           "type" : "string",
-          "enum": ["AND", "XOR", "N_OF_M"],
+          "enum": ["and", "xor", "n_of_m"],
           "description": "Option types on how to complete branch execution.",
-          "default": "AND"
+          "default": "and"
         },
         "n": {
           "type": "integer",
           "default": 0,
           "minimum": 0,
-          "description": "Used when completionType is set to 'N_OF_M' to specify the 'N' value"
+          "description": "Used when completionType is set to 'n_of_m' to specify the 'N' value"
         },
         "retry": {
           "type": "array",
@@ -865,7 +865,7 @@
         "type": {
           "type": "string",
           "enum": [
-            "SWITCH"
+            "switch"
           ],
           "description": "State type"
         },
@@ -950,7 +950,7 @@
         "type": {
           "type": "string",
           "enum": [
-            "SWITCH"
+            "switch"
           ],
           "description": "State type"
         },
@@ -1051,7 +1051,7 @@
         },
         "operator": {
           "type" : "string",
-          "enum": ["Exists", "NotExists", "Null", "NotNull", "Equals", "NotEquals", "LessThan", "LessThanOrEquals", "GreaterThan", "GreaterThanOrEquals", "Matches", "NotMatches", "Custom"],
+          "enum": ["exists", "notexists", "null", "notnull", "equals", "notequals", "lessthan", "lessthanorequals", "greaterthan", "greaterthanorequals", "matches", "notmatches", "custom"],
           "description": "Condition operator"
         },
         "transition": {
@@ -1080,7 +1080,7 @@
         "type": {
           "type": "string",
           "enum": [
-            "SUBFLOW"
+            "subflow"
           ],
           "description": "State type"
         },
@@ -1183,7 +1183,7 @@
         "type": {
           "type": "string",
           "enum": [
-            "INJECT"
+            "inject"
           ],
           "description": "State type"
         },
@@ -1269,7 +1269,7 @@
         "type": {
           "type": "string",
           "enum": [
-            "FOREACH"
+            "foreach"
           ],
           "description": "State type"
         },
@@ -1440,7 +1440,7 @@
         },
         "type": {
           "type" : "string",
-          "enum": ["CALLBACK"],
+          "enum": ["callback"],
           "description": "State type"
         },
         "action": {
@@ -1574,20 +1574,20 @@
         "kind": {
           "type": "string",
           "enum": [
-            "DEFAULT",
-            "SCHEDULED"
+            "default",
+            "scheduled"
           ],
           "description": "Kind of start definition"
         },
         "schedule": {
-          "description": "If kind is SCHEDULED, define when the starting state is or becomes active",
+          "description": "If kind is scheduled, define when the starting state is or becomes active",
           "$ref": "#/definitions/schedule"
         }
       },
       "if": {
         "properties": {
           "kind": {
-            "const": "SCHEDULED"
+            "const": "scheduled"
           }
         }
       },
@@ -1623,21 +1623,21 @@
         "kind": {
           "type": "string",
           "enum": [
-            "DEFAULT",
-            "TERMINATE",
-            "EVENT"
+            "default",
+            "terminate",
+            "event"
           ],
           "description": "Kind of end definition"
         },
         "produceEvent": {
-          "description": "If end kind is EVENT, select one of the defined events by name and set its data",
+          "description": "If end kind is event, select one of the defined events by name and set its data",
           "$ref": "#/definitions/produceevent"
         }
       },
       "if": {
         "properties": {
           "kind": {
-            "const": "EVENT"
+            "const": "event"
           }
         }
       },

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -485,7 +485,7 @@ Following is a detailed description of each of the defined states:
         },
         "type": {
             "type" : "string",
-            "enum": ["EVENT"],
+            "enum": ["event"],
             "description": "State type"
         },
         "exclusive": {
@@ -643,9 +643,9 @@ have not been received during this time, the state should transition to the next
         },
         "actionMode": {
             "type" : "string",
-            "enum": ["SEQUENTIAL", "PARALLEL"],
+            "enum": ["sequential", "parallel"],
             "description": "Specifies how actions are to be performed (in sequence of parallel)",
-            "default": "SEQUENTIAL"
+            "default": "sequential"
         },
         "actions": {
             "type": "array",
@@ -693,7 +693,7 @@ between arrival of specified events. To give an example let's say we have:
 "states": [
 {
     "name": "ExampleEventState",
-    "type": "EVENT",
+    "type": "event",
     "exclusive": false,
     "timeout": "PT2M",
     "eventsActions": [
@@ -708,7 +708,7 @@ between arrival of specified events. To give an example let's say we have:
         }
     ],
     "end": {
-        "kind": "TERMINATE"
+        "kind": "terminate"
     }
 }
 ]
@@ -1018,14 +1018,14 @@ Defines a transition from point A to point B in the serverless workflow. For mor
         },
         "type": {
             "type" : "string",
-            "enum": ["OPERATION"],
+            "enum": ["operation"],
             "description": "State type"
         },
         "actionMode": {
             "type" : "string",
-            "enum": ["SEQUENTIAL", "PARALLEL"],
+            "enum": ["sequential", "parallel"],
             "description": "Specifies whether actions are performed in sequence or in parallel",
-            "default": "SEQUENTIAL"
+            "default": "sequential"
         },
         "actions": {
             "type": "array",
@@ -1131,6 +1131,63 @@ Once all actions have been performed, a transition to another state can occur.
 {
     "type": "object",
     "description": "Permits transitions to other states based on matched data condition or events",
+    "properties": {
+        "id": {
+            "type": "string",
+            "description": "Unique state id",
+            "minLength": 1
+        },
+        "name": {
+            "type": "string",
+            "description": "State name"
+        },
+        "type": {
+            "type" : "string",
+            "enum": ["switch"],
+            "description": "State type"
+        },
+        "conditions": {
+            "type": "array",
+            "description": "Defines conditions evaluated against state data",
+            "items": {
+                "type": "object",
+                "$ref": "#/definitions/condition"
+            }
+        },
+        "stateDataFilter": {
+          "$ref": "#/definitions/statedatafilter"
+        },
+        "onError": {
+            "type": "array",
+            "description": "States error handling definitions",
+            "items": {
+                "type": "object",
+                "$ref": "#/definitions/error"
+            }
+        },
+        "default": {
+            "description": "Next transition of the workflow if there is no match for any conditions",
+            "$ref": "#/definitions/transition"
+        },
+        "dataInputSchema": {
+          "type": "string",
+          "format": "uri",
+          "description": "URI to JSON Schema that state data input adheres to"
+        },
+        "dataOutputSchema": {
+          "type": "string",
+          "format": "uri",
+          "description": "URI to JSON Schema that state data output adheres to"
+        },
+        "metadata": {
+          "$ref": "#/definitions/metadata"
+        },
+        "start": {
+          "$ref": "#/definitions/start",
+          "description": "State start definition"
+        }
+    },
+>>>>>>> Change all uppercase properties and enum types to lowercase
     "oneOf": [
       {
         "$ref": "#/definitions/databasedswitch"
@@ -1188,10 +1245,10 @@ Switch states cannot be workflow ending states.
         },
         "operator": {
             "type" : "string",  
-            "enum": ["Exists", "NotExists", "Null", "NotNull",
-                     "Equals", "NotEquals", "LessThan", "LessThanOrEquals", 
-                     "GreaterThan", "GreaterThanOrEquals", "Matches", "NotMatches",
-                     "Custom"],
+            "enum": ["exists", "notexists", "null", "notnull",
+                     "equals", "notequals", "lessthan", "lessthanorequals", 
+                     "greaterthan", "greaterthanorequals", "matches", "notmatches",
+                     "custom"],
             "description": "Condition operator"
         },
         "transition": {
@@ -1296,7 +1353,7 @@ the "eventDataFilter" defines the event data filter to be used to filter event d
         },
         "type": {
             "type" : "string",
-            "enum": ["DELAY"],
+            "enum": ["delay"],
             "description": "State type"
         },
         "timeDelay": {
@@ -1392,7 +1449,7 @@ Delay state waits for a certain amount of time before transitioning to a next st
 | type | State type | string | yes |
 | [branches](#parallel-state-branch) | List of branches for this parallel state| array | yes |
 | completionType | Option types on how to complete branch execution. | enum | no |
-| n | Used when branchCompletionType is set to 'N_OF_M' to specify the 'N' value. | integer | no |
+| n | Used when branchCompletionType is set to 'n_of_m' to specify the 'N' value. | integer | no |
 | [stateDataFilter](#state-data-filter) | State data filter | object | no |
 | [retry](#workflow-retrying) | States retry definitions | array | no |
 | [onError](#Workflow-Error-Handling) | States error handling definitions | array | no |
@@ -1421,7 +1478,7 @@ Delay state waits for a certain amount of time before transitioning to a next st
         },
         "type": {
             "type" : "string",
-            "enum": ["PARALLEL"],
+            "enum": ["parallel"],
             "description": "State type"
         },
         "branches": {
@@ -1434,15 +1491,15 @@ Delay state waits for a certain amount of time before transitioning to a next st
         },
         "completionType": {
             "type" : "string",  
-            "enum": ["AND", "XOR", "N_OF_M"],
+            "enum": ["and", "xor", "n_of_m"],
             "description": "Option types on how to complete branch execution.",
-            "default": "AND"
+            "default": "and"
         },
         "n": {
            "type": "integer",
             "default": 0,
             "minimum": 0,
-            "description": "Used when completionType is set to 'N_OF_M' to specify the 'N' value"
+            "description": "Used when completionType is set to 'n_of_m' to specify the 'N' value"
         },
         "stateDataFilter": {
           "$ref": "#/definitions/statedatafilter"
@@ -1536,9 +1593,9 @@ Branches contain one or more states. Each branch must define one [starting state
 include at least one [end state](#End-Definition).
 
 The "completionType" enum specifies the different ways of completing branch execution:
-* AND: All branches must complete execution before state can perform its transition
-* XOR: State can transition when one of the branches completes execution
-* N_OF_M: State can transition once N number of branches have completed execution. In this case you should also
+* and: All branches must complete execution before state can perform its transition
+* xor: State can transition when one of the branches completes execution
+* n_of_m: State can transition once N number of branches have completed execution. In this case you should also
 specify the "n" property to define this number.
 
 
@@ -1650,7 +1707,7 @@ States outside a parallel state cannot transition to a states declared within br
         },
         "type": {
             "type" : "string",
-            "enum": ["SUBFLOW"],
+            "enum": ["subflow"],
             "description": "State type"
         },
         "waitForCompletion": {
@@ -1793,7 +1850,7 @@ If this property is set to false, data access to parent's workflow should not be
         },
         "type": {
             "type" : "string",
-            "enum": ["INJECT"],
+            "enum": ["inject"],
             "description": "State type"
         },
         "data": {
@@ -1887,7 +1944,7 @@ as data output to the transition state:
   ```json
   {  
    "name":"SimpleInjectState",
-   "type":"INJECT",
+   "type":"inject",
    "data": {
       "person": {
         "fname": "John",
@@ -1907,7 +1964,7 @@ as data output to the transition state:
 
 ```yaml
   name: SimpleInjectState
-  type: INJECT
+  type: inject
   data:
     person:
       fname: John
@@ -1952,7 +2009,7 @@ You can also use the filter property to filter the state data after data is inje
 ```json
   {  
      "name":"SimpleInjectState",
-     "type":"INJECT",
+     "type":"inject",
      "data": {
         "people": [
           {
@@ -1989,7 +2046,7 @@ You can also use the filter property to filter the state data after data is inje
 
 ```yaml
   name: SimpleInjectState
-  type: INJECT
+  type: inject
   data:
     people:
     - fname: John
@@ -2064,7 +2121,7 @@ This allows you to test if your workflow behaves properly for cases when there a
         },
         "type": {
             "type" : "string",
-            "enum": ["FOREACH"],
+            "enum": ["foreach"],
             "description": "State type"
         },
         "inputCollection": {
@@ -2285,17 +2342,17 @@ and the state is defined as:
   "states": [
   {
    "name":"SendConfirmationForEachCompletedhOrder",
-   "type":"FOREACH",
+   "type":"foreach",
    "inputCollection": "$.orders[?(@.completed == true)]",
    "inputParameter": "$.completedorder",
    "states": [
       {  
       "start": {
-         "kind": "DEFAULT"
+         "kind": "default"
       },
       "name":"SendConfirmation",
-      "type":"OPERATION",
-      "actionMode":"SEQUENTIAL",
+      "type":"operation",
+      "actionMode":"sequential",
       "actions":[  
       {  
        "functionRef": {
@@ -2307,12 +2364,12 @@ and the state is defined as:
        }
     }],
     "end": {
-      "kind": "DEFAULT"
+      "kind": "default"
     }
     }
  ],
  "end": {
-    "kind": "DEFAULT"
+    "kind": "default"
  }
 }
 ]
@@ -2328,15 +2385,15 @@ functions:
   resource: functionResourse
 states:
 - name: SendConfirmationForEachCompletedhOrder
-  type: FOREACH
+  type: foreach
   inputCollection: "$.orders[?(@.completed == true)]"
   inputParameter: "$.completedorder"
   states:
   - start:
-      kind: DEFAULT
+      kind: default
     name: SendConfirmation
-    type: OPERATION
-    actionMode: SEQUENTIAL
+    type: operation
+    actionMode: sequential
     actions:
     - functionRef:
         refName: sendConfirmationFunction
@@ -2344,9 +2401,9 @@ states:
           orderNumber: "$.completedorder.orderNumber"
           email: "$.completedorder.email"
     end:
-      kind: DEFAULT
+      kind: default
   end:
-    kind: DEFAULT
+    kind: default
 ```
 
 </td>
@@ -2464,7 +2521,7 @@ defined in the orders array of its data input.
         },
         "type": {
             "type" : "string",
-            "enum": ["CALLBACK"],
+            "enum": ["callback"],
             "description": "State type"
         },
         "action": {
@@ -2605,8 +2662,8 @@ If the defined callback event has not been received during this time period, the
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| kind | End kind ("DEFAULT", "SCHEDULED") | enum | yes |
-| [schedule](#Schedule-Definition) | If kind is "SCHEDULED", define when the starting state is or becomes active | object | yes only if kind is "SCHEDULED" |
+| kind | End kind ("default", "scheduled") | enum | yes |
+| [schedule](#Schedule-Definition) | If kind is "scheduled", define when the starting state is or becomes active | object | yes only if kind is "scheduled" |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -2618,20 +2675,20 @@ If the defined callback event has not been received during this time period, the
     "kind": {
       "type": "string",
       "enum": [
-        "DEFAULT",
-        "SCHEDULED"
+        "default",
+        "scheduled"
       ],
       "description": "Kind of start definition"
     },
     "schedule": {
-      "description": "If kind is SCHEDULED, define when the starting state is or becomes active",
+      "description": "If kind is scheduled, define when the starting state is or becomes active",
       "$ref": "#/definitions/schedule"
     }
   },
   "if": {
     "properties": {
       "kind": {
-        "const": "SCHEDULED"
+        "const": "scheduled"
       }
     }
   },
@@ -2656,8 +2713,8 @@ state to be executed. A workflow definition can declare one workflow start state
 
 The start definition provides a "kind" parameter which describes the starting options:
 
-- **DEFAULT** - The start state is always "active" and there are no restrictions imposed on its execution.
-- **SCHEDULED** -  The start state is only "active" as described in the schedule definition. Workflow instance creation can only be performed for this workflow
+- **default** - The start state is always "active" and there are no restrictions imposed on its execution.
+- **scheduled** -  The start state is only "active" as described in the schedule definition. Workflow instance creation can only be performed for this workflow
 as described by the provided schedule.
 
 Defining a schedule for the start definition allows you to model workflows which are only "active" during certain time intervals. For example let's say
@@ -2719,8 +2776,8 @@ Once a workflow instance is created, the start state schedule can be ignored for
 
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
-| kind | End kind ("DEFAULT", "TERMINATE", or "EVENT") | enum | yes |
-| [produceEvent](#ProduceEvent-Definition) | If kind is "EVENT", define what type of event to produce | object | yes only if kind is "EVENT" |
+| kind | End kind ("default", "terminate", or "event") | enum | yes |
+| [produceEvent](#ProduceEvent-Definition) | If kind is "event", define what type of event to produce | object | yes only if kind is "EVENT" |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -2732,21 +2789,21 @@ Once a workflow instance is created, the start state schedule can be ignored for
     "kind": {
       "type": "string",
       "enum": [
-        "DEFAULT",
-        "TERMINATE",
-        "EVENT"
+        "default",
+        "terminate",
+        "event"
       ],
       "description": "Kind of end definition"
     },
     "produceEvent": {
-      "description": "If end kind is EVENT, select one of the defined events by name and set its data",
+      "description": "If end kind is event, select one of the defined events by name and set its data",
       "$ref": "#/definitions/produceevent"
     }
   },
   "if": {
     "properties": {
       "kind": {
-        "const": "EVENT"
+        "const": "event"
       }
     }
   },
@@ -2770,10 +2827,10 @@ Any state with the exception of the [Switch](#Switch-State) state can declare to
 
 The end definitions provides different ways to complete workflow execution, which is set by the "kind" property:
 
-- **DEFAULT** - Default workflow execution completion, no other special behavior
-- **TERMINATE** - Completes all execution flows in the given workflow instance. All activities/actions being executed
+- **default** - Default workflow execution completion, no other special behavior
+- **terminate** - Completes all execution flows in the given workflow instance. All activities/actions being executed
 are completed. If a terminate end is reached inside a ForEach, Parallel, or SubFlow state, the entire workflow instance is terminated.
-- **EVENT** - Workflow executions completes, and a Cloud Event is produced according to the [produceEvent](#ProduceEvent-Definition) definition.
+- **event** - Workflow executions completes, and a Cloud Event is produced according to the [produceEvent](#ProduceEvent-Definition) definition.
 
 #### ProduceEvent Definition
 
@@ -2912,10 +2969,10 @@ output of the state to transition from includes an user with the title "MANAGER"
 "states":[  
   {  
    "start": {
-     "kind": "DEFAULT"
+     "kind": "default"
    },
    "name":"lowRiskState",
-   "type":"OPERATION",
+   "type":"operation",
    "actionMode":"Sequential",
    "actions":[  
     {  
@@ -2934,9 +2991,9 @@ output of the state to transition from includes an user with the title "MANAGER"
   },
   {  
    "name":"highRiskState",
-   "type":"OPERATION",
+   "type":"operation",
    "end": {
-     "kind": "DEFAULT"
+     "kind": "default"
    },
    "actionMode":"Sequential",
    "actions":[  
@@ -2962,9 +3019,9 @@ functions:
   resource: functionResourse
 states:
 - start:
-    kind: DEFAULT
+    kind: default
   name: lowRiskState
-  type: OPERATION
+  type: operation
   actionMode: Sequential
   actions:
   - functionRef:
@@ -2975,9 +3032,9 @@ states:
       language: spel
       body: "#jsonPath(stateOutputData,'$..user.title') eq 'MANAGER'"
 - name: highRiskState
-  type: OPERATION
+  type: operation
   end:
-    kind: DEFAULT
+    kind: default
   actionMode: Sequential
   actions:
   - functionRef:
@@ -3147,7 +3204,7 @@ we can define a state filter:
 ```json
 {
   "name": "FruitsOnlyState",
-  "type": "INJECT",
+  "type": "inject",
   "stateDataFilter": {
     "dataInputPath": "$.fruits"
   },
@@ -3171,7 +3228,7 @@ The first way would be to use both dataInputPath, and dataOutputPath:
 ```json
 {
   "name": "VegetablesOnlyState",
-  "type": "INJECT",
+  "type": "inject",
   "stateDataFilter": {
     "dataInputPath": "$.vegetables",
     "dataOutputPath": "$.[?(@.veggieLike)]"
@@ -3194,7 +3251,7 @@ The second way would be to directly filter only the "veggie like" vegetables wit
 ```json
 {
   "name": "VegetablesOnlyState",
-  "type": "INJECT",
+  "type": "inject",
   "stateDataFilter": {
     "dataInputPath": "$.vegetables.[?(@.veggieLike)]"
   },
@@ -3338,10 +3395,10 @@ and then lets us know how to greet this customer in different languages. We coul
     "states":[
         {
             "start": {
-               "kind": "DEFAULT"
+               "kind": "default"
             },
             "name": "WaitForCustomerToArrive",
-            "type": "EVENT",
+            "type": "event",
             "eventsActions": [{
                 "eventRefs": ["CustomerArrivesEvent"],
                 "eventDataFilter": {
@@ -3368,7 +3425,7 @@ and then lets us know how to greet this customer in different languages. We coul
                 "dataOutputPath": "$.finalCustomerGreeting"
             },
             "end": {
-              "kind": "DEFAULT"
+              "kind": "default"
             }
         }
     ]


### PR DESCRIPTION
Currently we enforce use of uppercase types and enums. This is not really the norm especially with our markup types (json/yaml). Changing to lowercase. Implementations can choose to ignore case or not. 