### PR TITLE
produceEvent data property update

### DIFF
--- a/workflow/spec/roadmap.md
+++ b/workflow/spec/roadmap.md
@@ -53,4 +53,5 @@ _Status description:_
 | ✔️| Add ability to produce events during state transitions | [spec doc](spec.md) |
 | ✔️| Add event-based condition capabilities to Switch State | [spec doc](spec.md) |
 | ✔️| Add examples comparing Brigade workflow and spec markups | [examples doc](examples-brigade.md) |
+| ✔️| Update produceEvent data property | [spec doc](spec.md) |
 

--- a/workflow/spec/schema/serverless-workflow-schema.json
+++ b/workflow/spec/schema/serverless-workflow-schema.json
@@ -1662,8 +1662,8 @@
           "description": "References a name of a defined event"
         },
         "data": {
-          "type": "string",
-          "description": "JSONPath expression which selects parts of the states data output to become the data of the produced event"
+          "type": ["string", "object"],
+          "description": "If String, JSONPath expression which selects parts of the states data output to become the data of the produced event. If object a custom object to become the data of produced event."
         }
       },
       "required": [

--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -2780,7 +2780,7 @@ are completed. If a terminate end is reached inside a ForEach, Parallel, or SubF
 | Parameter | Description | Type | Required |
 | --- | --- | --- | --- |
 | eventRef | Reference to a defined unique event name in the [events](#Event-Definition) definition | string | yes |
-| data | JSONPath expression which selects parts of the states data output to become the data of the produced event | string | no |
+| data | If String, JSONPath expression which selects parts of the states data output to become the data of the produced event. If object a custom object to become the data of produced event. | string or object | no |
 
 <details><summary><strong>Click to view JSON Schema</strong></summary>
 
@@ -2794,7 +2794,7 @@ are completed. If a terminate end is reached inside a ForEach, Parallel, or SubF
       "description": "References a name of a defined event"
     },
     "data": {
-      "type": "object",
+      "type": ["string", "object"],
       "description": "JSONPath expression which selects parts of the states data output to become the data of the produced event"
     }
   },


### PR DESCRIPTION
Currently in produceEvent, the data is just a string which is a json path expression selecting parts of the state data. In some cases you want to build your own data which may use the state data if needed for the produced event. 
This change allows users to do both.