### PR TITLE
Adding 'we have moved' to spec doc

### DIFF
--- a/workflow/spec/spec.md
+++ b/workflow/spec/spec.md
@@ -1,3 +1,7 @@
+<p align="center">
+<a href="https://github.com/cncf/wg-serverless-workflow" target="_blank"><img src="media/repo-moved.png" alt="We Moved!"/></a>
+</p>
+
 # Serverless Workflow
 
 ## Abstract


### PR DESCRIPTION
Google links directly to this doc for a "serverless workflow specification" search in its results. 
Adding the "We have moved" image here as well so readers know to go to the new repo where all the updates are now happening.