### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can open up suggestions and issues with the landscape here: https://github.c
 
 ## Interactive Landscape
 
-Please see the new interactive [version](https://landscape.cncf.io/format=serverless) of the landscape. The easy-to-remember URL is [s.cncf.io](https://s.cncf.io).
+Please see the new interactive [version](https://landscape.cncf.io/serverless) of the landscape. The easy-to-remember URL is [s.cncf.io](https://s.cncf.io).
 
 ## Serverless Overview Whitepaper
 


### PR DESCRIPTION
Interactive url looks like changed from https://landscape.cncf.io/format=serverless to https://landscape.cncf.io/serverless. The easy to remember url s.cncf.io also needs to change to point to correct url. But probably only owner can change it.



Signed-off-by: Jay1305 <31636584+Jay1305@users.noreply.github.com>