### PR TITLE
Remove unusual line terminator from README

### DIFF
--- a/whitepapers/serverless-overview/README.md
+++ b/whitepapers/serverless-overview/README.md
@@ -316,7 +316,7 @@ Drawbacks include lack of OS control, granular container portability and load ba
 
 ### Drawbacks
 
-* Loss of control over OS,  possibly at the mercy of buildpack versions.
+* Loss of control over OS, possibly at the mercy of buildpack versions.
 
 * More opinionated about application structure, tending towards [12-Factor](https://12factor.net/) microservices best practices at the potential cost of architecture flexibility.
 


### PR DESCRIPTION
This pull request makes a small improvement to the documentation in `whitepapers/serverless-overview/README.md`. The change removes an unnecessary special character from the drawbacks section, improving readability.